### PR TITLE
ADD OCL_LIBS in the right place for correct linking when ocl is enabled

### DIFF
--- a/linbox/Makefile.am
+++ b/linbox/Makefile.am
@@ -54,7 +54,7 @@ liblinbox_la_LIBADD =           \
     util/libutil.la             \
     randiter/libranditer.la     \
     algorithms/libalgorithms.la \
-    $(MPFR_LIBS) $(IML_LIBS) 
+    $(MPFR_LIBS) $(IML_LIBS) $(OCL_LIBS)
 
 #Cygwin ?
 liblinbox_la_LDFLAGS = \


### PR DESCRIPTION
Currently when ocl is enabled the ocl libraries are not used when linking liblinbox.so. This PR fix this situation.