### PR TITLE
Use the correct libdir in linbox.pc

### DIFF
--- a/linbox.pc.in
+++ b/linbox.pc.in
@@ -1,7 +1,7 @@
 /------------------ linbox.pc ------------------------
 prefix=@prefix@
 exec_prefix=@prefix@
-libdir=@prefix@/lib
+libdir=@libdir@
 includedir=@prefix@/include
 
 Name: linbox


### PR DESCRIPTION
Currently in `linbox.pc.in`, `libdir` is set to `@prefix@/lib` which ignore the scenario where `libdir` has been configured to something else on the command line (more commonly `/usr/lib64` for example). This PR correct that problem. I notice that `linbox-config.in` already has the correct value. It also goes further to take care of exotic scenario for `includedir` which I didn't do here.