### PR TITLE
Fixes linking interface modules as shared libraries on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,7 +156,20 @@ AC_PROG_LIBTOOL
 
 # newer libtool...
 LT_PREREQ([2.4.2])
-LT_INIT
+LT_INIT([win32-dll])
+
+
+# needed for building interfaces as shared libs on Windows
+AC_CANONICAL_HOST
+case "${host_os}" in
+    cygwin*|mingw*)
+        LINBOX_LDFLAGS=-no-undefined
+        ;;
+    *)
+        LINBOX_LDFLAGS=""
+        ;;
+esac
+AC_SUBST([LINBOX_LDFLAGS])
 
 
 echo "-----------------------------------------------"

--- a/interfaces/driver/Makefile.am
+++ b/interfaces/driver/Makefile.am
@@ -46,7 +46,7 @@ liblbdriver_la_SOURCES= lb-element.C 	\
 # \
 			#  lb-solve.C
 
-liblbdriver_la_LDFLAGS=  $(NTL_LIBS) $(LDFLAGS) $(top_srcdir)/linbox/liblinbox.la -Wl,-zmuldefs
+liblbdriver_la_LDFLAGS=  $(NTL_LIBS) $(LDFLAGS) $(LINBOX_LDFLAGS) $(top_srcdir)/linbox/liblinbox.la -Wl,-zmuldefs
 
 
 

--- a/interfaces/maple/Makefile.am
+++ b/interfaces/maple/Makefile.am
@@ -30,7 +30,7 @@ lib_LTLIBRARIES=liblbmaple.la
 
 liblbmaple_la_SOURCES= lb-maple.C
 
-liblbmaple_la_LDFLAGS=  $(NTL_LIBS) $(MAPLE_LIBS) $(top_srcdir)/interfaces/driver/liblbdriver.la -Wl,-zmuldefs $(LDFLAGS)
+liblbmaple_la_LDFLAGS=  $(NTL_LIBS) $(MAPLE_LIBS) $(top_srcdir)/interfaces/driver/liblbdriver.la -Wl,-zmuldefs $(LDFLAGS) $(LINBOX_LDFLAGS)
 
 pkginclude_HEADERS =lb-maple.h lb-maple-utilities.h
 

--- a/interfaces/sage/Makefile.am
+++ b/interfaces/sage/Makefile.am
@@ -38,5 +38,5 @@ pkginclude_HEADERS = linbox-sage.h
 #gentoo's linbox-1.1.6-fix-undefined-symbols.patch
 liblinboxsage_la_LIBADD = $(top_builddir)/linbox/liblinbox.la
 
-liblinboxsage_la_LDFLAGS = $(DEPS_LIBS) $(LDFLAGS) -version-info 0:0:0 #-Wl,-zmuldefs
+liblinboxsage_la_LDFLAGS = $(DEPS_LIBS) $(LDFLAGS) $(LINBOX_LDFLAGS) -version-info 0:0:0 #-Wl,-zmuldefs
 endif


### PR DESCRIPTION
This adds the necessary bits to compile shared libraries on Windows.  For reference, see https://www.gnu.org/software/libtool/manual/html_node/LT_005fINIT.html (under win32-dll).

See https://trac.sagemath.org/ticket/22318 for the original issue.