### PR TITLE
Simplification in gf2.h headers. Be more standard conformant

### DIFF
--- a/linbox/field/gf2.h
+++ b/linbox/field/gf2.h
@@ -41,11 +41,7 @@
 #include "linbox/field/field-traits.h"
 // #include "linbox/vector/vector-domain.h"
 
-#if !defined(__PATHCC__) && !(defined(__APPLE__) && defined(__clang__))
-#define stdBitReference std::_Bit_reference
-#else
 #define stdBitReference std::vector<bool>::reference
-#endif
 
 // Namespace in which all LinBox code resides
 namespace LinBox
@@ -1015,25 +1011,7 @@ namespace LinBox
 // Specialization of homomorphism for basefield
 #include "linbox/randiter/gf2.h"
 
-#if __cplusplus >= 201103L
-#if defined( __APPLE__) && defined(__clang__)
-#include <__bit_reference>
-#else
-#include <bits/stl_bvector.h>
-#endif /* __clang__ */
-#else
-// #include <bits/stl_bvector.h>
-{
-	//! @todo JGD 05.11.2009 : it should be in bits/stl_bvector.h  ...
-	inline void swap(stdBitReference __x, stdBitReference __y)
-	{
-		bool __tmp = __x;
-		__x = __y;
-		__y = __tmp;
-	}
-}
-#endif
-
+#include <vector>
 
 #include "linbox/field/gf2.inl"
 


### PR DESCRIPTION
This is intended as a fix for issue #46 which identified problems in `linbox/fields/gf2.h` when using clang. My own opinion is that scrubbing is needed. Some parts where implementation specific. In the top part of we have a conditional definition which was failing with a full clang because the condition was not precise enough. When examined fully, the two alternatives give the same results - the gcc specialisation is just the internal implementation of the standard non-gcc alternative on the other branch.

At the bottom of the the file we have again a specialisation depending on standard and compiler. It should all work in all cases if a standard header is used rather than implementation dependent ones. In this case the last default branch was there probably because a specialised header was sought instead of a standard one. 