### PR TITLE
Do not use 'B0' as a variable name

### DIFF
--- a/linbox/solutions/det.h
+++ b/linbox/solutions/det.h
@@ -236,9 +236,9 @@ namespace LinBox
 				}
 
 				Diagonal<Field> D (diag);
-				Compose<Blackbox,Diagonal<Field> > B0 (&A, &D);
+				Compose<Blackbox,Diagonal<Field> > B_0 (&A, &D);
 				typedef Compose<Diagonal<Field>,Compose<Blackbox,Diagonal<Field> > > Blackbox1;
-				Blackbox1 B(&D, &B0);
+				Blackbox1 B(&D, &B_0);
 
 				BlackboxContainerSymmetric<Field, Blackbox1> TF (&B, F, iter);
 

--- a/linbox/solutions/rank.inl
+++ b/linbox/solutions/rank.inl
@@ -142,9 +142,9 @@ namespace LinBox
 
 
 			typedef Compose<Compose<Diagonal<Field>,Blackbox >, Diagonal<Field> > BlackBox1;
-			Diagonal<Field> D0 (d1);
-			Compose<Diagonal<Field>,Blackbox > B0 (&D0, &A);
-			BlackBox1 B (&B0, &D0);
+			Diagonal<Field> D_0 (d1);
+			Compose<Diagonal<Field>,Blackbox > B_0 (&D_0, &A);
+			BlackBox1 B (&B_0, &D_0);
 
 			BlackboxContainerSymmetric<Field, BlackBox1> TF (&B, F, iter);
 			MasseyDomain<Field, BlackboxContainerSymmetric<Field, BlackBox1> > WD (&TF, M.earlyTermThreshold ());


### PR DESCRIPTION
`B0` unfortunately conflicts with a standard macro in `termios.h`.  This is the same issue as in linbox-team/fflas-ffpack#57