### PR TITLE
Cra full rewrite

### DIFF
--- a/linbox/algorithms/cra-domain.h
+++ b/linbox/algorithms/cra-domain.h
@@ -37,6 +37,7 @@
 
 #include "linbox/integer.h"
 #include "linbox/field/rebind.h"
+#include "linbox/vector/vector.h"
 
 namespace LinBox
 {
@@ -82,6 +83,21 @@ namespace LinBox
 			ResidueType<Domain> r;
 			d.init(r);
 			return r;
+		}
+	};
+
+	/** \brief Type information for the residue in a CRA iteration.
+	 *
+	 * This is the specialization for a vector of scalar types (namely Integer)
+	 */
+	template <typename Function>
+	struct CRAResidue<std::vector<Integer>, Function> {
+		template <typename Domain>
+		using ResidueType = DenseVector<Domain>;
+
+		template <typename Domain>
+		static ResidueType<Domain> create(const Domain& d) {
+            return ResidueType<Domain>(d);
 		}
 	};
 }

--- a/linbox/algorithms/cra-early-multip.h
+++ b/linbox/algorithms/cra-early-multip.h
@@ -214,27 +214,24 @@ namespace LinBox
 			EarlySingleCRA<Domain>::residue_ = 0;
 
 			/* Computation of residue_ */
-			std::vector< LazyProduct >::iterator _mod_it = FullMultipCRA<Domain>::RadixPrimeProd_.begin();// list of prime products
-			std::vector< std::vector<Integer> >::iterator _tab_it = FullMultipCRA<Domain>::RadixResidues_.begin();// list of residues as vectors of size 1
-			std::vector< bool >::iterator    _occ_it = FullMultipCRA<Domain>::RadixOccupancy_.begin();//flags of occupied fields
-			int prev_shelf=0, shelf = 0;
-			for (;_occ_it != FullMultipCRA<Domain>::RadixOccupancy_.end(); ++_mod_it, ++_tab_it, ++_occ_it ) {
-				++shelf;
-				if (*_occ_it) {
-					Integer D = _mod_it->operator()();
+            for (auto it = FullMultipCRA<Domain>::shelves_begin();
+                 it != FullMultipCRA<Domain>::shelves_end();
+                 ++it)
+            {
+                if (it->occupied) {
+					Integer D = it->mod();
 					std::vector<Integer> e_v(randv.size());
-					e_v = *_tab_it;
+					e_v = it->residue;
 					Integer z;
 					dot(z,D, e_v, randv);
 					Integer prev_residue_ = EarlySingleCRA<Domain>::residue_;
 					EarlySingleCRA<Domain>::progress(D,z);
 					if (prev_residue_ == EarlySingleCRA<Domain>::residue_ )
-						EarlySingleCRA<Domain>::occurency_ = EarlySingleCRA<Domain>::occurency_ +  (shelf - prev_shelf);
+						EarlySingleCRA<Domain>::occurency_ += it->count;
 					if ( EarlySingleCRA<Domain>::terminated() ) {
 						return true;
 					}
-					prev_shelf = shelf;
-				}
+                }
 			}
 			return false;
 		}

--- a/linbox/algorithms/cra-full-multip-fixed.h
+++ b/linbox/algorithms/cra-full-multip-fixed.h
@@ -46,8 +46,6 @@
 namespace LinBox
 {
 
-
-
 	/*! @ingroup CRA
 	 * @brief Chinese Remaindering Algorithm for multiple residues.
 	 * An upper bound is given on the size of the data to reconstruct.
@@ -58,32 +56,6 @@ namespace LinBox
 		typedef typename Domain::Element 	DomainElement;
 		typedef FullMultipFixedCRA<Domain> 	Self_t;
 
-		typedef std::vector<double>::iterator        DoubleVect_Iterator ;
-		typedef std::vector< bool >::iterator          BoolVect_Iterator ;
-		typedef std::vector< LazyProduct >::iterator   LazyVect_Iterator ;
-		typedef BlasVector< Givaro::ZRing<Integer> >                        IntVect ;
-		typedef IntVect::iterator                       IntVect_Iterator ;
-		typedef std::vector< IntVect >::iterator    IntVectVect_Iterator ;
-		typedef IntVect::const_iterator            IntVect_ConstIterator ;
-
-	protected:
-		const size_t				size;
-
-	private :
-		/*! \internal
-		 *  Intialize the Radix ladder.
-		 */
-		void _initialize ()
-		{
-			this->RadixSizes_.resize(1);
-			this->RadixPrimeProd_.resize(1);
-			Givaro::ZRing<Integer> ZZ ;
-			this->RadixResidues_.resize(1,BlasVector<Givaro::ZRing<Integer>>(ZZ));
-			this->RadixOccupancy_.resize(1);
-			this->RadixOccupancy_.front() = false;
-		}
-
-	public:
 		/*! Constructor.
 		 * @param p is a pair such that
 		 * - \c p.first is the size of a residue (ie. it would be 1 for \"FullSingle\")
@@ -92,10 +64,8 @@ namespace LinBox
 		 * .
 		 */
 		FullMultipFixedCRA(const std::pair<size_t,double>& p ) :
-		       	FullMultipCRA<Domain>(p.second), size(p.first)
-	       	{
-		       	this->_initialize();
-		}
+			FullMultipCRA<Domain>(p.second, p.first)
+        { }
 
 		/*! Intialize to the first residue/prime.
 		 * @param D domain
@@ -103,11 +73,8 @@ namespace LinBox
 		 * @pre any CRA should first call \c initialize before \c progress
 		 */
 		template<class Iterator>
-		void initialize (const Domain& D, Iterator& e)
-		{
-			this->_initialize();
-			this->progress(D, e);
-		}
+		inline void initialize (const Domain& D, Iterator& e)
+        { this->initialize_iter(D, e, this->dimension_); }
 
 		/*! Add a new residue (ie take into account a new prime).
 		 * @param D domain
@@ -115,186 +82,17 @@ namespace LinBox
 		 * <code>std::vector<T>::iterator</code>.
 		 */
 		template<class Iterator>
-		void progress (const Domain& D, Iterator& e)
-		{
-			// Radix shelves
-			DoubleVect_Iterator  _dsz_it = this->RadixSizes_.begin();
-			LazyVect_Iterator    _mod_it = this->RadixPrimeProd_.begin();
-			IntVectVect_Iterator _tab_it = this->RadixResidues_.begin();
-			BoolVect_Iterator    _occ_it = this->RadixOccupancy_.begin();
-
-			Givaro::ZRing<Integer> ZZ;
-			IntVect ri(ZZ,this->size);
-			LazyProduct mi;
-			double di;
-			if (*_occ_it) {
-				// If lower shelf is occupied
-				// Combine it with the new residue
-				// The for loop will transmit the resulting
-				// combination to the upper shelf
-				Iterator e_it = e;
-				IntVect_Iterator       ri_it = ri.begin();
-				IntVect_ConstIterator  t0_it = _tab_it->begin();
-
-				DomainElement invP0;
-				this->precomputeInvP0(invP0, D, _mod_it->operator()() );
-
-				for( ; ri_it != ri.end(); ++e_it, ++ri_it, ++ t0_it){
-					this->fieldreconstruct(*ri_it, D, *e_it, *t0_it, invP0,
-							       (*_mod_it).operator()() );
-				}
-				Integer tmp;
-				D.characteristic(tmp);
-				double ltp = Givaro::naturallog(tmp);
-				di = *_dsz_it + ltp;
-				this->totalsize += ltp;
-				mi.mulin(tmp);
-				mi.mulin(*_mod_it);
-				*_occ_it = false;
-			}
-			else {
-				// Lower shelf is free
-				// Put the new residue here and exit
-				Integer tmp;
-				D.characteristic(tmp);
-				double ltp = Givaro::naturallog(tmp);
-				_mod_it->initialize(tmp);
-				*_dsz_it = ltp;
-				this->totalsize += ltp;
-				Iterator e_it = e;
-				_tab_it->resize(this->size);
-				IntVect_Iterator t0_it= _tab_it->begin();
-				for( ; t0_it != _tab_it->end(); ++e_it, ++ t0_it){
-					D.convert(*t0_it, *e_it);
-				}
-				*_occ_it = true;
-				return;
-			}
-
-			// We have a combination to put in the upper shelf
-			for(++_dsz_it, ++_mod_it, ++_tab_it, ++_occ_it ;
-			    _occ_it != this->RadixOccupancy_.end() ;
-			    ++_dsz_it, ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					// This shelf is occupied
-					// Combine it with the new combination
-					// The loop will try to put it on the upper shelf
-					IntVect_Iterator      ri_it = ri.begin();
-					IntVect_ConstIterator t_it  = _tab_it->begin();
-
-					Integer invprod;
-					this->precomputeInvProd(invprod, mi(), _mod_it->operator()());
-
-					for( ; ri_it != ri.end(); ++ri_it, ++ t_it)
-						this->smallbigreconstruct(*ri_it, *t_it, invprod);
-
-					// Product (lazy) computation
-					mi.mulin(*_mod_it);
-
-					// Moding out
-					for(ri_it = ri.begin() ; ri_it != ri.end(); ++ri_it) {
-						*ri_it %= mi();
-					}
-
-					di += *_dsz_it;
-					*_occ_it = false;
-				}
-				else {
-					// This shelf is free
-					// Put the new combination here and exit
-					*_dsz_it = di;
-					*_mod_it = mi;
-					*_tab_it = ri;
-					*_occ_it = true;
-					return;
-				}
-			}
-			// All the shelfves were occupied
-			// We create a new top shelf
-			// And put the new combination there
-			this->RadixSizes_.push_back( di );
-			this->RadixResidues_.push_back( ri );
-			this->RadixPrimeProd_.push_back( mi );
-			this->RadixOccupancy_.push_back ( true );
-		}
+		inline void progress (const Domain& D, Iterator& e)
+		{ this->progress_iter(D, e, this->dimension_); }
 
 		/*! Compute the result.
 		 * moves low occupied shelves up.
 		 * @param[out] d an iterator for the result.
 		 */
 		template<class Iterator>
-		Iterator& result (Iterator &d)
-		{
-			LazyVect_Iterator     _mod_it = this->RadixPrimeProd_.begin();
-			IntVectVect_Iterator  _tab_it = this->RadixResidues_.begin();
-			BoolVect_Iterator     _occ_it = this->RadixOccupancy_.begin();
-			LazyProduct Product;
-			// We have to find to lowest occupied shelf
-			for( ; _occ_it != this->RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					// Found the lowest occupied shelf
-					Product = *_mod_it;
-					Iterator t0_it = d;
-					IntVect_Iterator t_it = _tab_it->begin();
-					if (++_occ_it == this->RadixOccupancy_.end()) {
-						// It is the only shelf of the radix
-						// We normalize the result and output it
-						for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-							this->normalize(*t0_it = *t_it, *t_it,
-								  _mod_it->operator()());
-						this->RadixPrimeProd_.resize(1);
-						return d;
-					}
-					else {
-						// There are other shelves
-						// The result is initialized with this shelf
-						// The for loop will combine the other shelves m with the actual one
-						for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-							*t0_it  = *t_it;
-						++_mod_it; ++_tab_it;
-						break;
-					}
-				}
-			}
-			for( ; _occ_it != this->RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					// This shelf is occupied
-					// We need to combine it with the actual value of the result
-					Iterator t0_it = d;
-					IntVect_ConstIterator t_it = _tab_it->begin();
-
-					Integer invprod;
-					this->precomputeInvProd(invprod, Product(), _mod_it->operator()() );
-
-					for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-						this->smallbigreconstruct(*t0_it, *t_it, invprod);
-
-					// Overall product computation
-					Product.mulin(*_mod_it);
-
-					// Moding out and normalization
-					t0_it = d;
-					for(size_t i=0;i<this->size; ++i, ++t0_it) {
-						*t0_it %= Product();
-						Integer tmp(*t0_it);
-						this->normalize(*t0_it, tmp, Product());
-					}
-
-				}
-			}
-
-			// We put it also the final prime product in the first shelf of products
-			// JGD : should we also put the result
-			//       in the first shelf of residues and resize it to 1
-			//       and set to true the first occupancy and resize it to 1
-			//       in case result is not the last call (more progress to go) ?
-			this->RadixPrimeProd_.resize(1);
-			this->RadixPrimeProd_.front() = Product;
-			return d;
-		}
-
-	};
-
+		void result (Iterator &d) const
+        { this->result_iter(d); }
+    };
 }
 
 namespace LinBox
@@ -309,32 +107,6 @@ namespace LinBox
 		typedef typename Domain::Element 	DomainElement;
 		typedef FullMultipBlasMatCRA<Domain> 	Self_t;
 
-		typedef std::vector<double>::iterator        DoubleVect_Iterator ;
-		typedef std::vector< bool >::iterator          BoolVect_Iterator ;
-		typedef std::vector< LazyProduct >::iterator   LazyVect_Iterator ;
-		typedef BlasVector< Givaro::ZRing<Integer> >                        IntVect ;
-		typedef IntVect::iterator                       IntVect_Iterator ;
-		typedef std::vector< IntVect >::iterator    IntVectVect_Iterator ;
-		typedef IntVect::const_iterator            IntVect_ConstIterator ;
-
-	protected:
-		const size_t				size;
-
-	private :
-		/*! \internal
-		 *  Intialize the Radix ladder.
-		 */
-		void _initialize ()
-		{
-			this->RadixSizes_.resize(1);
-			this->RadixPrimeProd_.resize(1);
-			Givaro::ZRing<Integer> ZZ ;
-			this->RadixResidues_.resize(1,BlasVector<Givaro::ZRing<Integer>>(ZZ));
-			this->RadixOccupancy_.resize(1);
-			this->RadixOccupancy_.front() = false;
-		}
-
-	public:
 		/*! Constructor.
 		 * @param p is a pair such that
 		 * - \c p.first is the size of a residue, it would be 1 for \"FullSingle\"
@@ -343,8 +115,8 @@ namespace LinBox
 		 * .
 		 */
 		FullMultipBlasMatCRA(const std::pair<size_t,double>& p ) :
-		       	FullMultipCRA<Domain>(p.second), size(p.first)
-		{ }
+			FullMultipCRA<Domain>(p.second, p.first)
+        { }
 
 		/*! Intialize to the first residue/prime.
 		 * @param D domain
@@ -353,10 +125,7 @@ namespace LinBox
 		 */
 		template<class Matrix>
 		void initialize (const Domain& D, Matrix& e)
-		{
-			this->_initialize();
-			this->progress(D, e);
-		}
+        { this->initialize_iter(D, e.Begin(), this->dimension_); }
 
 		/*! Add a new residue (ie take into account a new prime).
 		 * @param D domain
@@ -364,107 +133,7 @@ namespace LinBox
 		 */
 		template<class Matrix>
 		void progress (const Domain& D, Matrix& e)
-		{
-			// Radix shelves
-			DoubleVect_Iterator  _dsz_it = this->RadixSizes_.begin();
-			LazyVect_Iterator    _mod_it = this->RadixPrimeProd_.begin();
-			IntVectVect_Iterator _tab_it = this->RadixResidues_.begin();
-			BoolVect_Iterator    _occ_it = this->RadixOccupancy_.begin();
-
-			Givaro::ZRing<Integer> ZZ;
-			IntVect ri(ZZ,this->size);
-			LazyProduct mi;
-			double di;
-			if (*_occ_it) {
-				// If lower shelf is occupied
-				// Combine it with the new residue
-				// The for loop will transmit the resulting
-				// combination to the upper shelf
-				typename Matrix::Iterator e_it = e.Begin();
-				IntVect_Iterator            ri_it = ri.begin();
-				IntVect_ConstIterator       t0_it = _tab_it->begin();
-
-				DomainElement invP0;
-			       	this->precomputeInvP0(invP0, D, _mod_it->operator()() );
-
-				for( ; ri_it != ri.end(); ++e_it, ++ri_it, ++ t0_it){
-					this->fieldreconstruct(*ri_it, D, *e_it, *t0_it, invP0,
-							       (*_mod_it).operator()() );
-				}
-				Integer tmp;
-				D.characteristic(tmp);
-				double ltp = Givaro::naturallog(tmp);
-				di = *_dsz_it + ltp;
-				this->totalsize += ltp;
-				mi.mulin(tmp);
-				mi.mulin(*_mod_it);
-				*_occ_it = false;
-			}
-			else {
-				// Lower shelf is free
-				// Put the new residue here and exit
-				Integer tmp;
-				D.characteristic(tmp);
-				double ltp = Givaro::naturallog(tmp);
-				_mod_it->initialize(tmp);
-				*_dsz_it = ltp;
-				this->totalsize += ltp;
-				typename Matrix::Iterator e_it = e.Begin();
-				_tab_it->resize(this->size);
-				IntVect_Iterator t0_it= _tab_it->begin();
-				for( ; t0_it != _tab_it->end(); ++e_it, ++ t0_it){
-					D.convert(*t0_it, *e_it);
-				}
-				*_occ_it = true;
-				return;
-			}
-
-			// We have a combination to put in the upper shelf
-			for(++_dsz_it, ++_mod_it, ++_tab_it, ++_occ_it ;
-			    _occ_it != this->RadixOccupancy_.end() ;
-			    ++_dsz_it, ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					// This shelf is occupied
-					// Combine it with the new combination
-					// The loop will try to put it on the upper shelf
-					IntVect_Iterator      ri_it = ri.begin();
-					IntVect_ConstIterator t_it  = _tab_it->begin();
-
-					Integer invprod;
-					this->precomputeInvProd(invprod, mi(), _mod_it->operator()());
-
-					for( ; ri_it != ri.end(); ++ri_it, ++ t_it)
-						this->smallbigreconstruct(*ri_it, *t_it, invprod);
-
-					// Product (lazy) computation
-					mi.mulin(*_mod_it);
-
-					// Moding out
-					for(ri_it = ri.begin() ; ri_it != ri.end(); ++ri_it) {
-						*ri_it %= mi();
-					}
-
-					di += *_dsz_it;
-					*_occ_it = false;
-				}
-				else {
-					// This shelf is free
-					// Put the new combination here and exit
-					*_dsz_it = di;
-					*_mod_it = mi;
-					*_tab_it = ri;
-					*_occ_it = true;
-					return;
-				}
-			}
-			// All the shelfves were occupied
-			// We create a new top shelf
-			// And put the new combination there
-			this->RadixSizes_.push_back( di );
-			this->RadixResidues_.push_back( ri );
-			this->RadixPrimeProd_.push_back( mi );
-			this->RadixOccupancy_.push_back ( true );
-		}
+		{ this->progress_iter(D, e.Begin(), this->dimension_); }
 
 		/*! Compute the result.
 		 * moves low occupied shelves up.
@@ -472,78 +141,10 @@ namespace LinBox
 		 */
 		template<class Matrix>
 		Matrix& result (Matrix &d)
-		{
-			LazyVect_Iterator     _mod_it = this->RadixPrimeProd_.begin();
-			IntVectVect_Iterator  _tab_it = this->RadixResidues_.begin();
-			BoolVect_Iterator     _occ_it = this->RadixOccupancy_.begin();
-			LazyProduct Product;
-			size_t _j=0;
-			// We have to find to lowest occupied shelf
-			for( ; _occ_it != this->RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				++_j;
-				if (*_occ_it) {
-					// Found the lowest occupied shelf
-					Product = *_mod_it;
-					typename Matrix::Iterator t0_it = d.Begin();
-					IntVect_Iterator t_it = _tab_it->begin();
-					if (++_occ_it == this->RadixOccupancy_.end()) {
-						// It is the only shelf of the radix
-						// We normalize the result and output it
-						for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-							this->normalize(*t0_it = *t_it, *t_it,
-								  _mod_it->operator()());
-						this->RadixPrimeProd_.resize(1);
-						return d;
-					}
-					else {
-						// There are other shelves
-						// The result is initialized with this shelf
-						// The for loop will combine the other shelves m with the actual one
-						for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-							*t0_it  = *t_it;
-						++_mod_it; ++_tab_it;
-						break;
-					}
-				}
-			}
-			for( ; _occ_it != this->RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				++_j;
-				if (*_occ_it) {
-					// This shelf is occupied
-					// We need to combine it with the actual value of the result
-					typename Matrix::Iterator t0_it = d.Begin();
-					IntVect_ConstIterator t_it = _tab_it->begin();
-
-					Integer invprod;
-					this->precomputeInvProd(invprod, Product(), _mod_it->operator()() );
-
-					for( ; t_it != _tab_it->end(); ++t0_it, ++t_it)
-						this->smallbigreconstruct(*t0_it, *t_it, invprod);
-
-					// Overall product computation
-					Product.mulin(*_mod_it);
-
-					// Moding out and normalization
-					t0_it = d.Begin();
-					for(size_t i=0;i<this->size; ++i, ++t0_it) {
-						*t0_it %= Product();
-						Integer tmp(*t0_it);
-						this->normalize(*t0_it, tmp, Product());
-					}
-
-				}
-			}
-
-			// We put it also the final prime product in the first shelf of products
-			// JGD : should we also put the result
-			//       in the first shelf of residues and resize it to 1
-			//       and set to true the first occupancy and resize it to 1
-			//       in case result is not the last call (more progress to go) ?
-			this->RadixPrimeProd_.resize(1);
-			this->RadixPrimeProd_.front() = Product;
-			return d;
-		}
-
+        {
+            this->result_iter(d.Begin());
+            return d;
+        }
 	};
 
 }

--- a/linbox/algorithms/cra-full-multip.h
+++ b/linbox/algorithms/cra-full-multip.h
@@ -198,14 +198,15 @@ namespace LinBox
 		}
 
 		//! result
-		inline const std::vector<Integer>& result () const
+		inline const std::vector<Integer>& result (bool normalized=true) const
 		{
-            normalize();
+            if (normalized) normalize();
+            else collapse();
             return shelves_.back().residue;
         }
 
         template <class Vect>
-        inline Vect& result(Vect& r) const
+        inline Vect& result(Vect& r, bool normalized=true) const
         {
             r.resize(dimension_);
             result_iter(r.begin());
@@ -213,13 +214,14 @@ namespace LinBox
         }
 
         template <class Iter>
-        void result_iter (Iter r_it) const {
+        void result_iter (Iter r_it, bool normalized=true) const {
             if (shelves_.empty()) {
                 for (size_t i=0; i < dimension_; ++i)
                     *r_it = 0;
             }
             else {
-                normalize();
+                if (normalized) normalize();
+                else collapse();
                 std::copy_n(shelves_.back().residue.begin(), dimension_, r_it);
             }
         }
@@ -236,6 +238,9 @@ namespace LinBox
             }
             return false;
 		}
+
+        size_t getDimension() const
+        { return dimension_; }
 
         // XXX iterator invalidated by many other method calls
         decltype(shelves_.crbegin()) shelves_begin() const {

--- a/linbox/algorithms/cra-full-multip.h
+++ b/linbox/algorithms/cra-full-multip.h
@@ -321,7 +321,7 @@ namespace LinBox
             --halfm;
             halfm >>= 1;
             for (auto& x : const_cast<std::vector<Integer>&>(shelves_.back().residue)) {
-                x %= shelves_.back().mod();
+                Integer::modin(x, shelves_.back().mod());
                 if (x > halfm) x -= shelves_.back().mod();
             }
             const_cast<bool&>(normalized_) = true;

--- a/linbox/algorithms/cra-full-multip.h
+++ b/linbox/algorithms/cra-full-multip.h
@@ -200,8 +200,7 @@ namespace LinBox
 		//! result
 		inline const std::vector<Integer>& result (bool normalized=true) const
 		{
-            if (normalized) normalize();
-            else collapse();
+            normalize();
             return shelves_.back().residue;
         }
 
@@ -220,8 +219,7 @@ namespace LinBox
                     *r_it = 0;
             }
             else {
-                if (normalized) normalize();
-                else collapse();
+                normalize();
                 std::copy_n(shelves_.back().residue.begin(), dimension_, r_it);
             }
         }
@@ -299,8 +297,9 @@ namespace LinBox
             else {
                 Integer temp;
                 auto cur = ncshelves.begin();
+                while (! cur->occupied) ++cur;
+                auto next = cur;
                 while(true) {
-                    auto next = cur;
                     if (++next == ncshelves.end()) break;
                     while (! next->occupied) ++next;
                     combineShelves(*next, *cur, temp);

--- a/linbox/algorithms/cra-full-multip.h
+++ b/linbox/algorithms/cra-full-multip.h
@@ -97,13 +97,6 @@ namespace LinBox
             return shelves_.back().mod();
         }
 
-        // alias for result
-		template<class Vect>
-		inline Vect& getResidue(Vect& r) const
-		{
-			return result(r);
-		}
-
 		//! init
 		template<typename ModType, class Vect>
 		inline void initialize (const ModType& D, const Vect& e)
@@ -224,6 +217,19 @@ namespace LinBox
             }
         }
 
+        // alias for result
+		inline const std::vector<Integer>& getResidue() const
+		{
+			return result();
+		}
+
+        // alias for result
+		template<class Vect>
+		inline Vect& getResidue(Vect& r) const
+		{
+			return result(r);
+		}
+
 		bool terminated() const
 		{
 			return totalsize_ > LOGARITHMIC_UPPER_BOUND;
@@ -343,7 +349,8 @@ namespace LinBox
 		}
 
 
-		static Integer& smallbigreconstruct(Integer& u1, const Integer& u0, const Integer& invprod)
+        template <typename IntegerLike>
+		static Integer& smallbigreconstruct(Integer& u1, const IntegerLike& u0, const Integer& invprod)
 		{
 			u1 -= u0;	  // u1 <-- (u1-u0)
 			u1 *= invprod;    // u1 <-- (u1-u0)( m0^{-1} mod m1 ) m0

--- a/linbox/algorithms/cra-givrnsfixed.h
+++ b/linbox/algorithms/cra-givrnsfixed.h
@@ -109,26 +109,12 @@ namespace LinBox
 		}
 
 
-		template< template<class, class> class Vect, template <class> class Alloc>
-		void progress (const Domain& D, const Vect<DomainElement, Alloc<DomainElement> >& e)
+        template <typename Vect>
+		void progress (const Domain& D, const Vect& e)
 		{
 			++iterationnumber;
-			typename Vect<DomainElement, Alloc<DomainElement> >::const_iterator eit=e.begin();
-			std::vector<std::vector< Integer > >::iterator rit = residues.begin();
-
-			for( ; eit != e.end(); ++eit, ++rit) {
-				Integer tmp;
-				D.convert(tmp, *eit);
-				rit->push_back(tmp);
-			}
-
-		}
-
-		void progress (const Domain& D, const BlasVector<Domain>& e)
-		{
-			++iterationnumber;
-			typename BlasVector<Domain >::const_iterator eit=e.begin();
-			std::vector<BlasVector< Givaro::ZRing<Integer> > >::iterator rit = residues.begin();
+			auto eit=e.begin();
+			auto rit = residues.begin();
 
 			for( ; eit != e.end(); ++eit, ++rit) {
 				Integer tmp;
@@ -139,13 +125,13 @@ namespace LinBox
 		}
 
 
-		template<template<class, class> class Vect, template <class> class Alloc>
-		Vect<Integer, Alloc<Integer> >& result (Vect<Integer, Alloc<Integer> > &d)
+        template <typename Vect>
+        Vect& result(Vect &d)
 		{
 			d.resize(0);
-			for(typename Vect<Integer, Alloc<Integer> >::const_iterator rit = residues.begin(); rit != residues.end(); ++rit) {
+            for (auto& res : residues) {
 				Integer tmp;
-				RnsToRing(tmp, *rit);
+				RnsToRing(tmp, res);
 				linbox_check(tmp>=0);
 				linbox_check(tmp<_product);
 				if (tmp>_midprod)
@@ -156,22 +142,6 @@ namespace LinBox
 			return d;
 		}
 
-
-		BlasVector<Givaro::ZRing<Integer> >& result (BlasVector<Givaro::ZRing<Integer> > &d)
-		{
-			d.resize(0);
-			for(std::vector<BlasVector< Givaro::ZRing<Integer> > >::const_iterator rit = residues.begin(); rit != residues.end(); ++rit) {
-				Integer tmp;
-				RnsToRing(tmp, *rit);
-				linbox_check(tmp>=0);
-				linbox_check(tmp<_product);
-				if (tmp>_midprod)
-					tmp -= _product ;
-				linbox_check(tmp<=_midprod);
-				d.push_back(tmp);
-			}
-			return d;
-		}
 
 		bool terminated()
 		{

--- a/linbox/algorithms/cra-single.h
+++ b/linbox/algorithms/cra-single.h
@@ -36,6 +36,7 @@
 #include "linbox/integer.h"
 #include "linbox/solutions/methods.h"
 #include "linbox/algorithms/cra-domain.h"
+#include "linbox/algorithms/cra-full-multip.h"
 #include <vector>
 #include <array>
 #include <utility>
@@ -455,7 +456,7 @@ namespace LinBox
 		typedef SingleCRABase<Domain_Type>	Base;
 		typedef Domain_Type			Domain;
 		typedef typename Domain::Element DomainElement;
-		typedef EarlySingleCRA<Domain> Self_t;
+		typedef ProbSingleCRA<Domain> Self_t;
 
 	protected:
 		const size_t bitbound_;
@@ -560,14 +561,12 @@ namespace LinBox
 	 *
 	 */
 	template<class Domain_Type>
-	struct FullSingleCRA :public SingleCRABase<Domain_Type> {
+	struct FullSingleCRA :public FullMultipCRA<Domain_Type>{
 		typedef SingleCRABase<Domain_Type>	Base;
 		typedef Domain_Type			Domain;
 		typedef typename Domain::Element DomainElement;
-		typedef EarlySingleCRA<Domain> Self_t;
-
-	protected:
-		const size_t bitbound_;
+		typedef FullSingleCRA<Domain> Self_t;
+        using MultiParent = FullMultipCRA<Domain>;
 
 	public:
 		/** @brief Creates a new deterministic CRA object.
@@ -576,7 +575,7 @@ namespace LinBox
 		 * @param	failprob  An upper bound on the probability of failure.
 		 */
 		FullSingleCRA(const size_t bitbound) :
-			bitbound_(bitbound)
+            MultiParent(((double)bitbound) * log(2.0))
 		{
 		}
 
@@ -596,7 +595,8 @@ namespace LinBox
 		template <typename ModType, typename ResType>
 		void initialize (const ModType& D, const ResType& e)
 		{
-			Base::initialize(D,e);
+            std::array<ResType,1> v {e};
+            MultiParent::initialize(D,v);
 		}
 
 		/** @brief Update the residue and termination condition.
@@ -617,17 +617,29 @@ namespace LinBox
 		void progress (const ModType& D, const ResType& e)
 		{
 			// Precondition : initialize has been called once before
-			// linbox_check(curfailprob_ >= 0.);
-			Base::progress_check(D,e);
+            std::array<ResType,1> v {e};
+            MultiParent::progress(D, v);
 		}
 
-		/** @brief Checks whether the CRA is finished.
-		 *
-		 * @return true iff the early termination condition has been reached.
+		/** @brief Gets the result recovered so far.
 		 */
-		bool terminated() const
+		inline const Integer& getResidue() const
 		{
-			return Base::modbits() > bitbound_;
+            return MultiParent::getResidue().front();
+		}
+
+		/** @brief Gets the result recovered so far.
+		 */
+		inline Integer& getResidue(Integer& r) const
+		{
+			return r = getResidue();
+		}
+
+		/** @brief alias for getResidue
+		 */
+		inline Integer& result(Integer& r) const
+		{
+			return r = getResidue();
 		}
 	};
 

--- a/linbox/algorithms/lazy-product.h
+++ b/linbox/algorithms/lazy-product.h
@@ -63,20 +63,8 @@ namespace LinBox
 
 		bool mulin(const Integer& i)
 		{
-			if (this->size()) {
-				if (i != this->back()) {
-					this->push_back( i );
-					return _tobecomputed = true;
-				}
-				else {
-					return _tobecomputed;
-				}
-
-			}
-			else {
-				this->push_back( i );
-				return _tobecomputed = false;
-			}
+            this->emplace_back(i);
+            return _tobecomputed = (this->size() > 1);
 		}
 
 		bool mulin(const LazyProduct& i)

--- a/linbox/algorithms/lazy-product.h
+++ b/linbox/algorithms/lazy-product.h
@@ -35,6 +35,19 @@ namespace LinBox
 		typedef std::vector< Integer > Father_t;
 	protected:
 		bool                _tobecomputed;
+
+        void compute() {
+            if (this->empty()) {
+                this->emplace_back(1);
+                _tobecomputed = false;
+            } else if (_tobecomputed) {
+                for (auto iter = ++(this->begin()); iter != this->end(); ++iter)
+                    this->front() *= *iter;
+                this->resize(1);
+				_tobecomputed = false;
+			}
+        }
+
 	public:
 
 		LazyProduct() :
@@ -72,17 +85,20 @@ namespace LinBox
 			return _tobecomputed = (this->size()>1);
 		}
 
-		Integer & operator() ()
+        Integer& operator() ()
+        {
+            compute();
+            return this->front();
+        }
+
+		const Integer& operator() () const
 		{
-			if (_tobecomputed) {
-				Father_t::const_iterator iter = this->begin();
-				Father_t::iterator       prod = this->begin();
-				for(++iter; iter != this->end(); ++iter)
-					*prod *= *iter;
-				this->resize(1);
-				_tobecomputed = false;
-			}
-			return this->back();
+            /* note: const_cast is because this method does not change
+             * the underlying value, so it should be const, but the
+             * underlying vector cannot be mutable since it is inherited.
+             */
+            const_cast<LazyProduct*>(this)->compute();
+			return this->front();
 		}
 
 		bool noncoprime(const Integer& i) const

--- a/linbox/algorithms/rational-cra-full-multip.h
+++ b/linbox/algorithms/rational-cra-full-multip.h
@@ -31,17 +31,6 @@
 namespace LinBox
 {
 
-#if 0
-	template<class T, template <class T> class Container>
-	std::ostream& operator<< (std::ostream& o, const Container<T>& C) {
-		for(typename Container<T>::const_iterator refs =  C.begin();
-		    refs != C.end() ;
-		    ++refs )
-			o << (*refs) << " " ;
-		return o << std::endl;
-	}
-#endif
-
 	template<class Domain_Type>
 	struct FullMultipRatCRA : public virtual FullMultipCRA<Domain_Type> {
 		typedef Domain_Type				Domain;
@@ -51,151 +40,30 @@ namespace LinBox
 		Givaro::ZRing<Integer> _ZZ;
 	public:
 
-		using Father_t::RadixSizes_;
-		using Father_t::RadixResidues_;
-		using Father_t::RadixPrimeProd_;
-		using Father_t::RadixOccupancy_;
-
-
 		FullMultipRatCRA(const double BOUND = 0.0) :
 			Father_t(BOUND)
 		{}
 
 
-		template<template<class, class> class Vect, template <class> class Alloc>
-		Vect<Integer, Alloc<Integer> >& result (Vect<Integer, Alloc<Integer> > &num, Integer& den)
+        template <class Vect>
+		Vect& result (Vect &num, Integer& den)
 		{
-			num.resize( (Father_t::RadixResidues_.front()).size() );
-			std::vector< LazyProduct >::iterator 			_mod_it = Father_t::RadixPrimeProd_.begin();
-			std::vector< std::vector< Integer > >::iterator _tab_it = Father_t::RadixResidues_.begin();
-			std::vector< bool >::iterator    				_occ_it = Father_t::RadixOccupancy_.begin();
-			LazyProduct Product;
-			for( ; _occ_it != Father_t::RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					Product = *_mod_it;
-					std::vector<Integer>::iterator t0_it = num.begin();
-					std::vector<Integer>::iterator t_it = _tab_it->begin();
-					if (++_occ_it == Father_t::RadixOccupancy_.end()) {
-						den = 1;
-						Integer s, nd; _ZZ.sqrt(s, _mod_it->operator()());
-						for( ; t0_it != num.end(); ++t0_it, ++t_it) {
-							iterativeratrecon(*t0_it = *t_it, nd, den, _mod_it->operator()(), s);
-							if (nd > 1) {
-								std::vector<Integer>::iterator  t02 = num.begin();
-								for( ; t02 != t0_it ; ++t02)
-									*t02 *= nd;
-								den *= nd;
-							}
-						}
-						return num;
-					}
-					else {
-						for( ; t0_it != num.end(); ++t0_it, ++t_it)
-							*t0_it  = *t_it;
-						++_mod_it; ++_tab_it;
-						break;
-					}
-				}
-			}
-			for( ; _occ_it != Father_t::RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					std::vector<Integer>::iterator t0_it = num.begin();
-					std::vector<Integer>::const_iterator t_it = _tab_it->begin();
-					Integer invprod;
-					this->precomputeInvProd(invprod, Product(), _mod_it->operator()() );
-					for( ; t0_it != num.end(); ++t0_it, ++t_it)
-						this->smallbigreconstruct(*t0_it, *t_it, invprod );
-					Product.mulin(*_mod_it);
+            Father_t::result(num, false);
+            den = 1;
+            const auto& mod = Father_t::getModulus();
+            Integer s, nd;
+            _ZZ.sqrt(s, mod);
+            for (auto num_it = num.begin(); num_it != num.end(); ++num_it) {
+                iterativeratrecon(*num_it, nd, den, mod, s);
 
-					// Moding out and normalization
-					for(t0_it = num.begin();t0_it != num.end(); ++t0_it) {
-						*t0_it %= Product();
-						Integer tmp(*t0_it);
-						this->normalize(*t0_it, tmp, Product());
-					}
-				}
-			}
-			den = 1;
-			Integer s, nd; _ZZ.sqrt(s, Product.operator()());
-			std::vector<Integer>::iterator t0_it = num.begin();
-			for( ; t0_it != num.end(); ++t0_it) {
-				iterativeratrecon(*t0_it, nd, den, Product.operator()(), s);
-				if (nd > 1) {
-					std::vector<Integer>::iterator  t02 = num.begin();
-					for( ; t02 != t0_it ; ++t02)
-						*t02 *= nd;
-					den *= nd;
-				}
-			}
-			return num;
-		}
-
-		BlasVector<Givaro::ZRing<Integer> >& result (BlasVector<Givaro::ZRing<Integer>> &num, Integer& den)
-		{
-			num.resize( (Father_t::RadixResidues_.front()).size() );
-			std::vector< LazyProduct >::iterator            _mod_it = Father_t::RadixPrimeProd_.begin();
-			std::vector< BlasVector<Givaro::ZRing<Integer>> >::iterator _tab_it = Father_t::RadixResidues_.begin();
-			std::vector< bool >::iterator                   _occ_it = Father_t::RadixOccupancy_.begin();
-			LazyProduct Product;
-			for( ; _occ_it != Father_t::RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					Product = *_mod_it;
-					BlasVector<Givaro::ZRing<Integer>>::iterator t0_it = num.begin();
-					BlasVector<Givaro::ZRing<Integer>>::iterator t_it = _tab_it->begin();
-					if (++_occ_it == Father_t::RadixOccupancy_.end()) {
-						den = 1;
-						Integer s, nd; _ZZ.sqrt(s, _mod_it->operator()());
-						for( ; t0_it != num.end(); ++t0_it, ++t_it) {
-							iterativeratrecon(*t0_it = *t_it, nd, den, _mod_it->operator()(), s);
-							if (nd > 1) {
-								BlasVector<Givaro::ZRing<Integer>>::iterator  t02 = num.begin();
-								for( ; t02 != t0_it ; ++t02)
-									*t02 *= nd;
-								den *= nd;
-							}
-						}
-						return num;
-					}
-					else {
-						for( ; t0_it != num.end(); ++t0_it, ++t_it)
-							*t0_it  = *t_it;
-						++_mod_it; ++_tab_it;
-						break;
-					}
-				}
-			}
-			for( ; _occ_it != Father_t::RadixOccupancy_.end() ; ++_mod_it, ++_tab_it, ++_occ_it) {
-				if (*_occ_it) {
-					BlasVector<Givaro::ZRing<Integer> >::iterator t0_it = num.begin();
-					BlasVector<Givaro::ZRing<Integer> >::const_iterator t_it = _tab_it->begin();
-					Integer invprod;
-					this->precomputeInvProd(invprod, Product(), _mod_it->operator()() );
-					for( ; t0_it != num.end(); ++t0_it, ++t_it)
-						this->smallbigreconstruct(*t0_it, *t_it, invprod );
-					Product.mulin(*_mod_it);
-
-					// Moding out and normalization
-					for(t0_it = num.begin();t0_it != num.end(); ++t0_it) {
-						*t0_it %= Product();
-						Integer tmp(*t0_it);
-						this->normalize(*t0_it, tmp, Product());
-					}
-				}
-			}
-			den = 1;
-			Integer s, nd; _ZZ.sqrt(s, Product.operator()());
-			BlasVector<Givaro::ZRing<Integer> >::iterator t0_it = num.begin();
-			for( ; t0_it != num.end(); ++t0_it) {
-				iterativeratrecon(*t0_it, nd, den, Product.operator()(), s);
-				if (nd > 1) {
-					BlasVector<Givaro::ZRing<Integer> >::iterator  t02 = num.begin();
-					for( ; t02 != t0_it ; ++t02)
-						*t02 *= nd;
-					den *= nd;
-				}
-			}
-			return num;
-		}
+                if (nd > 1) {
+                    for (auto t02 = num.begin(); t02 != num_it; ++t02)
+                        *t02 *= nd;
+                    den *= nd;
+                }
+            }
+            return num;
+        }
 
 	protected:
 		Integer& iterativeratrecon(Integer& u1, Integer& new_den, const Integer& old_den, const Integer& m1, const Integer& s)

--- a/linbox/algorithms/signature.h
+++ b/linbox/algorithms/signature.h
@@ -142,6 +142,7 @@ namespace LinBox
 		template <class Matrix>
 		static bool isPosSemiDef (const Matrix& M, const BLAS_LPM_Method& meth)
             {
+                // FIXME this doesn't actually affect the seeding for the algorithms
                 PrimeIterator<IteratorCategories::HeuristicTag>::setSeed((size_t)time(0));
                 size_t n = M. rowdim();
                 std::vector<int> P;
@@ -170,7 +171,6 @@ namespace LinBox
                     }
                     semiD (D, PM);
                 }
-
                     //std::clog << "End semiD:\n";
 
                 return allPos(D);

--- a/linbox/algorithms/varprec-cra-early-multip.h
+++ b/linbox/algorithms/varprec-cra-early-multip.h
@@ -459,42 +459,32 @@ namespace LinBox
 			EarlySingleCRA<Domain>::residue_ = 0;
 
 			//Computation of residue_
-
-			//std::vector< double >::iterator  _dsz_it = RadixSizes_.begin();
-			std::vector< LazyProduct >::iterator _mod_it = FullMultipCRA<Domain>::RadixPrimeProd_.end();// list of prime products
-			std::vector< BlasVector<Givaro::ZRing<Integer> > >::iterator _tab_it = FullMultipCRA<Domain>::RadixResidues_.end();// list of residues as vectors of size 1
-			std::vector< bool >::iterator    _occ_it = FullMultipCRA<Domain>::RadixOccupancy_.end();//flags of occupied fields
-			int n = (int)FullMultipCRA<Domain>::RadixOccupancy_.size();
-			//std::vector<Integer> ri(1); LazyProduct mi; double di;
-			//could be much faster if max occupandy is stored
-			int prev_shelf=0, shelf = 0; Integer prev_residue_=0;
-			--_occ_it; --_mod_it; --_tab_it;//last elemet
-			for (int i=n; i > 0; --i, --_mod_it, --_tab_it, --_occ_it ) {
-				//--_occ_it; --_mod_it; --_tab_it;
-				++shelf;
-				if (*_occ_it) {
-					Integer D = _mod_it->operator()();
+            for (auto it = FullMultipCRA<Domain>::shelves_begin();
+                 it != FullMultipCRA<Domain>::shelves_end();
+                 ++it)
+            {
+                if (it->occupied) {
+					Integer D = it->mod();
 					Vect e_v(Z,vfactor_.size());
 					inverse(e_v,vfactor_,D);
-					productin(e_v,*_tab_it,D);
+					productin(e_v,it->residue,D);
 					productin(e_v,vmultip_,D);
 
 					Integer z;
 					dot(z,D, e_v, randv);
 
 
-					prev_residue_ = EarlySingleCRA<Domain>::residue_;
+				    auto prev_residue_ = EarlySingleCRA<Domain>::residue_;
 					EarlySingleCRA<Domain>::progress(D,z);
 
 					if (prev_residue_ == EarlySingleCRA<Domain>::residue_ ) {
-						EarlySingleCRA<Domain>::occurency_ = EarlySingleCRA<Domain>::occurency_ + (unsigned int) (shelf - prev_shelf);
+						EarlySingleCRA<Domain>::occurency_ += it->count;
 					}
 					if ( EarlySingleCRA<Domain>::terminated() ) {
 						return true;
 					}
-					prev_shelf = shelf;
-				}
-			}
+                }
+            }
 
 			return EarlySingleCRA<Domain>::terminated();
 

--- a/linbox/algorithms/varprec-cra-early-single.h
+++ b/linbox/algorithms/varprec-cra-early-single.h
@@ -284,34 +284,26 @@ namespace LinBox
 			EarlySingleCRA<Domain>::residue_ = 0;
 
 			//Computation of residue_
-
-			//std::vector< double >::iterator  _dsz_it = RadixSizes_.begin();//nie wiem
-			std::vector< LazyProduct >::iterator          _mod_it = FullMultipCRA<Domain>::RadixPrimeProd_.end(); // list of prime products
-			std::vector< BlasVector<Givaro::ZRing<Integer> > >::iterator _tab_it = FullMultipCRA<Domain>::RadixResidues_.end();  // list of residues as vectors of size 1
-			std::vector< bool >::iterator                 _occ_it = FullMultipCRA<Domain>::RadixOccupancy_.end(); //flags of occupied fields
-			int n= (int) FullMultipCRA<Domain>::RadixOccupancy_.size();
-			//BlasVector<Givaro::ZRing<Integer> > ri(1); LazyProduct mi; double di;//nie wiem
-			// could be much faster if max occupandy is stored
-			--_mod_it; --_tab_it; --_occ_it;
-			int prev_shelf=0, shelf = 0; Integer prev_residue_ =0;
-			for (int i=n; i > 0 ; --i, --_mod_it, --_tab_it, --_occ_it ) {
-				++shelf;
-				if (*_occ_it) {
-					Integer D = _mod_it->operator()();
+            for (auto it = FullMultipCRA<Domain>::shelves_begin();
+                 it != FullMultipCRA<Domain>::shelves_end();
+                 ++it)
+            {
+                if (it->occupied) {
+					Integer D = it->mod();
 					Integer e_i;
 
 					inv(e_i,factor_,D);
 					//!@todo use faster mul/mod here !
-					Integer::mulin(e_i, (_tab_it->front()));
+					Integer::mulin(e_i, (it->residue.front()));
 					Integer::mulin(e_i, multip_);
 					e_i %=D ;
 
 
-					prev_residue_ = EarlySingleCRA<Domain>::residue_;
+					Integer prev_residue_ = EarlySingleCRA<Domain>::residue_;
 					EarlySingleCRA<Domain>::progress(D,e_i);
 
 					if (prev_residue_ == EarlySingleCRA<Domain>::residue_ ) {
-						EarlySingleCRA<Domain>::occurency_ = EarlySingleCRA<Domain>::occurency_ + (unsigned int)  (shelf - prev_shelf);
+						EarlySingleCRA<Domain>::occurency_ += it->count;
 					}
 
 
@@ -319,9 +311,8 @@ namespace LinBox
 					if ( EarlySingleCRA<Domain>::terminated() ) {
 						return true;
 					}
-					prev_shelf = shelf;
-				}
-			}
+                }
+            }
 
 			return false;
 		}

--- a/tests/test-cra.C
+++ b/tests/test-cra.C
@@ -36,6 +36,7 @@
 #include "linbox/algorithms/cra-domain.h"
 #include "linbox/algorithms/cra-single.h"
 #include "linbox/algorithms/cra-early-multip.h"
+#include "linbox/algorithms/rational-cra-full-multip.h"
 
 #include "linbox/matrix/dense-matrix.h"
 #include "linbox/algorithms/cra-full-multip.h"
@@ -559,6 +560,120 @@ int test_full_multip(std::ostream & report, size_t PrimeSize, size_t Size, size_
 	return EXIT_SUCCESS ;
 }
 
+// testing FullMultipRatCRA
+template< class T>
+int test_full_multip_rat(std::ostream & report, size_t PrimeSize, size_t Size, size_t Taille)
+{
+	typedef typename std::vector<T>                    Vect ;
+	typedef std::vector<Integer>                    IntVect ;
+
+	typedef Givaro::Modular<double >           ModularField ;
+	typedef ModularField::Element                    Element;
+	typedef typename std::vector<Element>             pVect ;
+
+    static_assert(std::is_same<T,Element>::value, "Can only test modular<double> for now");
+
+    /* true answer */
+    size_t bitlen = (PrimeSize-1) * Size / 2;
+    Integer act_den = Integer::random(bitlen);
+    IntVect act_num(Taille);
+    for (auto& num_elt : act_num) {
+        num_elt = Integer::random<false>(bitlen);
+    }
+
+	Vect primes ;
+    std::vector<ModularField> fields;
+    Vect denom_imgs;
+	/*  probably not all coprime... */
+	PrimeIterator<IteratorCategories::HeuristicTag> RP((unsigned )PrimeSize);
+	for (size_t i = 0 ; i < Size ; ++i) {
+        fields.emplace_back(*RP);
+        denom_imgs.emplace_back();
+        while (fields.back().isZero(fields.back().init(denom_imgs.back(), act_den))) {
+            // hit a denominator divisor, try again
+            ++RP;
+            fields.pop_back();
+            fields.emplace_back(*RP);
+        }
+        primes.emplace_back(*RP);
+        ++RP;
+	}
+
+	/*  residues */
+    std::vector<pVect> residues;
+    for (size_t i=0; i < Size; ++i) {
+        residues.emplace_back(Taille);
+        for (size_t j=0; j < Taille; ++j) {
+            fields[i].init(residues.back()[j], act_num[j]);
+            fields[i].divin(residues.back()[j], denom_imgs[i]);
+        }
+	}
+
+	auto genprime = primes.begin()  ; // prime iterator
+    auto field_it = fields.begin();
+	auto residu = residues.begin()  ; // residu iterator
+
+	double LogIntSize = (double)PrimeSize*std::log(2.)+std::log((double)Size)+1 ;
+
+	report << "FullMultipRatCRA (" <<  LogIntSize << ')' << std::endl;
+	FullMultipRatCRA<ModularField> cra( LogIntSize ) ;
+	IntVect res_num(Taille) ; // the result
+    Integer res_den;
+	{ /* init */
+		cra.initialize(*field_it, *residu);
+		++genprime;
+        ++field_it;
+		++residu;
+	}
+	while (genprime != primes.end() /* && !cra.terminated()*/ )
+	{ /* progress */
+		if (cra.noncoprime((integer)*genprime))
+		{
+			report << "bad luck, you picked twice the same prime..." <<std::endl;
+			report << "FullMultipRatCRA exiting successfully." << std::endl;
+			return EXIT_SUCCESS ; // pas la faute à cra...
+		}
+		cra.progress(*field_it,*residu);
+		++genprime;
+        ++field_it;
+		++residu ;
+	}
+
+	cra.result(res_num, res_den);
+
+    if (act_den % res_den != 0) {
+        report << " *** FullMultipRatCRA failed. ***" << std::endl;
+        report << "denominator mismatch: " << res_den << " != " << act_den << std::endl;
+        return EXIT_FAILURE ;
+    }
+    Integer dm = act_den / res_den;
+
+    for (size_t i = 0; i < Taille; ++i) {
+        if (act_num[i] != res_num[i]*dm) {
+            report << " *** FullMultipRatCRA failed. ***" << std::endl;
+            report << "numerator mismatch: " << res_num[i] << " != " << act_num[i] << std::endl;
+            return EXIT_FAILURE ;
+        }
+    }
+
+	for (size_t i = 0 ; i < Size ; ++i){
+		for (size_t j = 0 ; j < Taille ; ++j) {
+			Element tmp1, tmp2 ;
+			fields[i].init(tmp1,res_num[j]);
+            fields[i].init(tmp2, res_den);
+            fields[i].mulin(tmp2, residues[i][j]);
+			if(!fields[i].areEqual(tmp1,tmp2)){
+				report << " *** FullMultipRatCRA failed. ***" << std::endl;
+				return EXIT_FAILURE ;
+			}
+		}
+	}
+
+	report << "FullMultipRatCRA exiting successfully." << std::endl;
+
+	return EXIT_SUCCESS ;
+}
+
 
 
 #if 1 /* testing FullMultipFixedCRA */
@@ -713,6 +828,10 @@ bool test_CRA_algos(size_t PrimeSize, size_t Size, size_t Taille, size_t iters)
 
 #endif
 
+    /* FULL MULTIPLE RATIONAL */
+	_LB_REPEAT( if (test_full_multip_rat<double>(report,22,Size,Taille))                 pass = false ;  ) ;
+	_LB_REPEAT( if (test_full_multip_rat<double>(report,22,Size,Taille/4))                 pass = false ;  ) ;
+
 	return pass ;
 
 }
@@ -752,7 +871,7 @@ int main(int ac, char ** av)
 
 	pass = test_CRA_algos(PrimeSize,Size,Taille,iters) ;
 
-	commentator().stop(MSG_STATUS (pass), (const char *) 0,"CRA-Algos test suite");
+	commentator().stop(MSG_STATUS (pass), "CRA-Algos test suite");
 	return !pass ;
 }
 

--- a/tests/test-cradomain.C
+++ b/tests/test-cradomain.C
@@ -40,15 +40,28 @@
 
 using namespace LinBox;
 
+template <class IntVect>
+inline IntVect create_int_vect(size_t size, Givaro::ZRing<Integer> F = Givaro::ZRing<Integer>());
+
+template <class IntVect>
+inline IntVect create_int_vect(size_t size, Givaro::ZRing<Integer>)
+{ return IntVect(size); }
+
+template <>
+BlasVector<Givaro::ZRing<Integer>> create_int_vect(size_t size, Givaro::ZRing<Integer> F)
+{ return BlasVector<Givaro::ZRing<Integer>>(F, size); }
+
+
+template <class IntVect_t = BlasVector<Givaro::ZRing<Integer>>>
 struct Interator {
-	BlasVector<Givaro::ZRing<Integer> > _v;
+    using IntVect = IntVect_t;
+	IntVect _v;
 	double maxsize;
 
-	Interator(const BlasVector<Givaro::ZRing<Integer> >& v) :
+	Interator(const IntVect& v) :
 		_v(v), maxsize(0.0)
 	{
-		for(BlasVector<Givaro::ZRing<Integer> > ::const_iterator it=_v.begin();
-		    it != _v.end(); ++it) {
+		for(auto it=_v.begin(); it != _v.end(); ++it) {
 			//!@bug bb: *it < 0 ?
 			double ds = Givaro::naturallog(*it);
 			maxsize = (maxsize<ds?ds:maxsize);
@@ -56,32 +69,30 @@ struct Interator {
 	}
 
 	Interator(int n, int s) :
-		_v(Givaro::ZRing<Integer>(),(size_t)n), maxsize(0.0)
+		_v(create_int_vect<IntVect>(n)), maxsize(0.0)
 	{
-		for(BlasVector<Givaro::ZRing<Integer> >::iterator it=_v.begin();
-		    it != _v.end(); ++it) {
+		for(auto it=_v.begin(); it != _v.end(); ++it) {
 			Integer::random<false>(*it, s);
 			double ds = Givaro::naturallog(*it);
 			maxsize = (maxsize<ds?ds:maxsize);
 		}
 	}
 
-	const BlasVector<Givaro::ZRing<Integer> >& getVector()
+	const IntVect& getVector() const
 	{
 	       	return _v;
-       	}
+    }
 	double getLogSize() const
 	{
 	       	return maxsize;
 	}
 
-	template<typename Field>
-	IterationResult operator()(BlasVector<Field>& v,
-				      const Field& F) const
+	template<typename Vect, typename Field>
+	IterationResult operator()(Vect& v, const Field& F) const
 	{
 		v.resize(_v.size());
-		BlasVector<Givaro::ZRing<Integer> >::const_iterator vit=_v.begin();
-		typename BlasVector<Field>::iterator eit=v.begin();
+		auto vit=_v.begin();
+		auto eit=v.begin();
 		for( ; vit != _v.end(); ++vit, ++eit){
 			F.init(*eit, *vit);
 		}
@@ -90,24 +101,25 @@ struct Interator {
 	}
 };
 
-struct InteratorIt : public Interator {
+template <class IntVect = BlasVector<Givaro::ZRing<Integer>>>
+struct InteratorIt : public Interator<IntVect> {
 
 	// could use BlasVector and changeField
 	mutable std::vector<double> _vectC;
 
-	InteratorIt(const BlasVector<Givaro::ZRing<Integer> >& v) :
-		Interator(v), _vectC(v.size())
+	InteratorIt(const IntVect& v) :
+		Interator<IntVect>(v), _vectC(v.size())
 	{}
 	InteratorIt(int n, int s) :
-		Interator(n,s), _vectC((size_t)n)
+		Interator<IntVect>(n,s), _vectC((size_t)n)
 	{}
 
 	template<typename Iterator, typename Field>
 	IterationResult operator()(Iterator& res, const Field& F) const
 	{
-		BlasVector<Givaro::ZRing<Integer> >::const_iterator vit=this->_v.begin();
-		std::vector<double>::iterator eit=_vectC.begin();
-		for( ; vit != _v.end(); ++vit, ++eit) {
+		auto vit=this->_v.begin();
+		auto eit=_vectC.begin();
+		for( ; vit != this->_v.end(); ++vit, ++eit) {
 			F.init(*eit, *vit);
 		}
 
@@ -117,30 +129,30 @@ struct InteratorIt : public Interator {
 
 };
 
-template<typename Field>
-struct InteratorBlas : public Interator {
+template<typename Field, class IntVect = BlasVector<Givaro::ZRing<Integer>>>
+struct InteratorBlas : public Interator<IntVect> {
 	typedef typename Field::Element Element;
 	typedef LinBox::BlasMatrix<Givaro::ZRing<Element> > Matrix;
 	typedef typename Matrix::pointer Pointer;
 	typename Givaro::ZRing<Element> _field;
 	mutable Matrix _vectC;
 
-	InteratorBlas(const BlasVector<Givaro::ZRing<Integer> >& v) :
-		Interator(v),
+	InteratorBlas(const IntVect& v) :
+		Interator<IntVect>(v),
 		_field(),
 		_vectC(_field,(int)v.size(), (int)1)
 	{}
 
 	InteratorBlas(int n, int s) :
-		Interator(n,s),
+		Interator<IntVect>(n,s),
 		_field(),
 		_vectC(_field,n,1) {}
 
 	IterationResult operator()(Pointer& res, const Field& F) const
 	{
-		BlasVector<Givaro::ZRing<Integer> >::const_iterator vit=this->_v.begin();
+		auto vit=this->_v.begin();
 		res = _vectC.getWritePointer();
-		for( ; vit != _v.end(); ++vit, ++res)
+		for( ; vit != this->_v.end(); ++vit, ++res)
 			F.init(*res, *vit);
 
 		res=_vectC.getWritePointer();
@@ -157,18 +169,19 @@ bool TestOneCRA(std::ostream& report, Iter& iteration, RandGen& genprime, size_t
 {
 	report << "ChineseRemainder<" << typeid(Builder).name() << ">(" << bound << ')' << std::endl;
 	LinBox::ChineseRemainder< Builder > cra( bound );
-	Givaro::ZRing<Integer> Z;
-	BlasVector<Givaro::ZRing<Integer> > Res(Z,N);
+    auto Res = create_int_vect<typename Iter::IntVect>(N);
 	cra( Res, iteration, genprime);
 	bool locpass = std::equal( Res.begin(), Res.end(), iteration.getVector().begin() );
 	if (locpass) report << "ChineseRemainder<" << typeid(Builder).name() << ">(" << iteration.getLogSize() << ')' << ", passed."  << std::endl;
 	else {
 		report << "***ERROR***: ChineseRemainder<" << typeid(Builder).name() << ">(" << iteration.getLogSize() << ')' << "***ERROR***"  << std::endl;
-		BlasVector<Givaro::ZRing<Integer> >::const_iterator Rit=Res.begin();
-		BlasVector<Givaro::ZRing<Integer> >::const_iterator Oit=iteration.getVector().begin();
+		auto Rit=Res.begin();
+		auto Oit=iteration.getVector().begin();
 		for( ; Rit!=Res.end(); ++Rit, ++Oit)
-			if (*Rit != *Oit)
+			if (*Rit != *Oit) {
 				report << *Rit <<  " != " << * Oit << std::endl;
+                { Integer a = *Rit, b; cra.getModulus(b); a += b; report << "adding mod: " << a<< std::endl; }
+            }
 
 	}
 	return locpass;
@@ -229,28 +242,28 @@ bool TestCra(size_t N, int S, size_t seed)
 	report << "TestCra(" << N << ',' << S << ',' << new_seed << ')' << std::endl;
 	Integer::seeding(new_seed);
 
-	Interator iteration((int)N, S);
-	InteratorIt iterationIt(iteration.getVector());
+    // either of these should work
+    using IntVect = BlasVector<Givaro::ZRing<Integer>>;
+    // using IntVect = std::vector<Integer>;
+
+	Interator<IntVect> iteration((int)N, S);
+	InteratorIt<IntVect> iterationIt(iteration.getVector());
         typedef Givaro::ModularBalanced<double> Field;
-	InteratorBlas<Field > iterationBlas(iteration.getVector());
+	InteratorBlas<Field, IntVect> iterationBlas(iteration.getVector());
 	PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(N), new_seed );
 
 	bool pass = true;
 
-	pass &= TestOneCRA< LinBox::EarlyMultipCRA< Field >,
-	     Interator, LinBox::PrimeIterator<IteratorCategories::HeuristicTag> >(
+	pass &= TestOneCRA< LinBox::EarlyMultipCRA< Field > >(
 						     report, iteration, genprime, N, 5);
 
-	pass &= TestOneCRA< LinBox::EarlyMultipCRA< Field >,
-	     Interator, LinBox::PrimeIterator<IteratorCategories::HeuristicTag> >(
+	pass &= TestOneCRA< LinBox::EarlyMultipCRA< Field > >(
 						     report, iteration, genprime, N, 15);
 
-	pass &= TestOneCRA< LinBox::FullMultipCRA< Field >,
-	     Interator, LinBox::PrimeIterator<IteratorCategories::HeuristicTag> >(
+	pass &= TestOneCRA< LinBox::FullMultipCRA< Field > >(
 						     report, iteration, genprime, N, iteration.getLogSize()+1);
 
-	pass &= TestOneCRA< LinBox::FullMultipCRA< Field >,
-	     Interator, LinBox::PrimeIterator<IteratorCategories::HeuristicTag> >(
+	pass &= TestOneCRA< LinBox::FullMultipCRA< Field > >(
 						     report, iteration, genprime, N, 3*iteration.getLogSize()+15);
 
 #if 0
@@ -285,7 +298,7 @@ bool TestCra(size_t N, int S, size_t seed)
 
 	// XXX fixed prime set doesn't work with openmp version
 #ifndef LINBOX_USES_OPENMP
-        BlasVector<Givaro::ZRing<Integer> >  PrimeSet(Z);
+        auto PrimeSet = create_int_vect<IntVect>(0,Z);
         double PrimeSize = 0.0;
         for( ; PrimeSize < (iterationIt.getLogSize()+1); ++genprime ) {
             if (std::find(PrimeSet.begin(), PrimeSet.end(), *genprime) == PrimeSet.end()) {
@@ -296,11 +309,7 @@ bool TestCra(size_t N, int S, size_t seed)
 
 	auto psseq = create_prime_sequence(PrimeSet);
 
-	pass &= TestOneCRA<
-            LinBox::GivaroRnsFixedCRA< Field >,
-            Interator,
-	    decltype(psseq),
-            BlasVector<Givaro::ZRing<Integer> >  >(
+	pass &= TestOneCRA< LinBox::GivaroRnsFixedCRA< Field > >(
                  report, iteration, psseq, N, PrimeSet);
 #endif
 


### PR DESCRIPTION
The FullMultipCRA class in algorithms/cra-full-multip.h has been redesigned, as documented in that file. This has the benefit of good asymptotic performance in CRA even when the modulus sizes are different, such as when a CRA is restarted etc.

Rather than having four vectors for the shelves data, there is a single vector of structs and a convenient interface to iterate over the shelves (in reverse order). Many other classes that were diving into the internal details of FullMultipCRA can use this interface instead for simplicity. A few other classes are almost entirely eliminated as minor specializations of FullMultipCRA instead of rewriting the logic.