### PR TITLE
Routines for serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ tests/test-modular-balanced-double
 tests/test-modular-balanced-int
 tests/test-moore-penrose
 tests/test-rational-reconstruction-base
+tests/test-serialization
 tests/test-smith-form-kannan-bachem
 tests/test-solve-nonsingular
 
@@ -43,6 +44,7 @@ tests/checker
 tests/checker.dSYM/
 tests/temp2
 
+.vscode/
 INSTALL
 _configs.sed
 aclocal.m4
@@ -87,3 +89,4 @@ macros/ltversion.m4
 macros/lt~obsolete.m4
 stamp-h1
 linbox.pc
+autogen.status

--- a/linbox/util/serialization.h
+++ b/linbox/util/serialization.h
@@ -1,0 +1,156 @@
+/* Copyright (C) 2018 The LinBox group
+ *
+ * ========LICENCE========
+ * This file is part of the library LinBox.
+ *
+  * LinBox is free software: you can redistribute it and/or modify
+ * it under the terms of the  GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * ========LICENCE========
+ */
+
+#pragma once
+
+#include <linbox/config.h>
+#include <linbox/integer.h>
+#include <linbox/matrix/dense-matrix.h>
+#include <linbox/matrix/sparse-matrix.h>
+#include <linbox/vector/blas-vector.h>
+#include <vector>
+
+/**
+ * Provides way to serialize any kind of data,
+ * like matrices, vectors and Integer in a platform-independent way.
+ *
+ * Serialize functions add data to a prexisting vector of bytes,
+ * they return the number of bytes written.
+ * Unserialize ones read a vector of bytes starting at a specific offset,
+ * the number of bytes read.
+ *
+ * As a convention, all numbers are written little-endian.
+ *
+ * @todo GMP Integers can be configured with limbs of different sizes (32 or 64 bits),
+ * depending on the machine. We do not handle that right now,
+ * but storing info about they dimension might be a good idea,
+ * to at least emit a warning.
+ */
+
+namespace LinBox {
+    // Basic serializations
+
+    uint64_t serialize(std::vector<uint8_t>& bytes, float value);
+    uint64_t serialize(std::vector<uint8_t>& bytes, double value);
+
+    uint64_t serialize(std::vector<uint8_t>& bytes, int8_t value);
+    uint64_t serialize(std::vector<uint8_t>& bytes, uint8_t value);
+
+    uint64_t serialize(std::vector<uint8_t>& bytes, int16_t value);
+    uint64_t serialize(std::vector<uint8_t>& bytes, uint16_t value);
+
+    uint64_t serialize(std::vector<uint8_t>& bytes, int32_t value);
+    uint64_t serialize(std::vector<uint8_t>& bytes, uint32_t value);
+
+    uint64_t serialize(std::vector<uint8_t>& bytes, int64_t value);
+    uint64_t serialize(std::vector<uint8_t>& bytes, uint64_t value);
+
+    // Basic unserializations
+
+    uint64_t unserialize(float& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+    uint64_t unserialize(double& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    uint64_t unserialize(int8_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+    uint64_t unserialize(uint8_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    uint64_t unserialize(int16_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+    uint64_t unserialize(uint16_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    uint64_t unserialize(int32_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+    uint64_t unserialize(uint32_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    uint64_t unserialize(int64_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+    uint64_t unserialize(uint64_t& value, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    /**
+     * Serializes an Integer with its underlying __mpz_struct.
+     * Returns the number of bytes written.
+     *
+     * Format is (by bytes count):
+     *  0-3  _mp_size   Number of mp_limb_t in _mp_d, can be negative to indicate negative number.
+     *  4-.. _mp_d      The limbs of length (abs(_mp_size) * sizeof(mp_limb_t))
+     */
+    uint64_t serialize(std::vector<uint8_t>& bytes, const Integer& integer);
+
+    /**
+     * Unserializes an Integer.
+     */
+    uint64_t unserialize(Integer& integer, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    /**
+     * Serializes a BlasMatrix.
+     *
+     * Format is (by bytes count):
+     *  0-7  n      Row dimension of matrix
+     *  8-15 m      Column dimension of matrix
+     *  16-..       Entries of the matrix, (n * m) row-majored
+     */
+    template <class Field>
+    uint64_t serialize(std::vector<uint8_t>& bytes, const BlasMatrix<Field>& M);
+
+    /**
+     * Unserializes a BlasMatrix.
+     * The matrix will be resized if necessary.
+     */
+    template <class Field>
+    uint64_t unserialize(BlasMatrix<Field>& M, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    /**
+     * Serializes a SparseMatrix.
+     *
+     * Format is (by bytes count):
+     *  0-7   n     Row dimension of matrix
+     *  8-15  m     Column dimension of matrix
+     *  16-23 size  Number of non-zero entries in the matrix
+     *  24-..       Entries of the matrix, only non-zero, stored as:
+     *      0-7  i      Row index
+     *      8-15 j      Column index
+     *      16-..       Entry value
+     */
+    template <class Field>
+    uint64_t serialize(std::vector<uint8_t>& bytes, const SparseMatrix<Field>& M);
+
+    /**
+     * Unserializes a SparseMatrix.
+     * The matrix will be resized if necessary.
+     */
+    template <class Field>
+    uint64_t unserialize(SparseMatrix<Field>& M, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+
+    /**
+     * Serializes a BlasVector.
+     *
+     * Format is (by bytes count):
+     *  0-7  l      Length of the vector
+     *  16-..       Entries of the vector
+     */
+    template <class Field>
+    uint64_t serialize(std::vector<uint8_t>& bytes, const BlasVector<Field>& V);
+
+    /**
+     * Unserializes a BlasVector.
+     * The vector will be resized if necessary.
+     */
+    template <class Field>
+    uint64_t unserialize(BlasVector<Field>& V, const std::vector<uint8_t>& bytes, uint64_t offset = 0u);
+}
+
+#include "serialization.inl"

--- a/linbox/util/serialization.h
+++ b/linbox/util/serialization.h
@@ -41,7 +41,7 @@
  *
  * @todo GMP Integers can be configured with limbs of different sizes (32 or 64 bits),
  * depending on the machine. We do not handle that right now,
- * but storing info about they dimension might be a good idea,
+ * but storing info about their dimension might be a good idea,
  * to at least emit a warning.
  */
 

--- a/linbox/util/serialization.inl
+++ b/linbox/util/serialization.inl
@@ -1,0 +1,342 @@
+/* Copyright (C) 2018 The LinBox group
+ *
+ * ========LICENCE========
+ * This file is part of the library LinBox.
+ *
+  * LinBox is free software: you can redistribute it and/or modify
+ * it under the terms of the  GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ * ========LICENCE========
+ */
+
+#pragma once
+
+#include "serialization.h"
+
+namespace LinBox {
+    // ----- Basic serializations
+
+    template <class T>
+    inline uint64_t serialize_raw(std::vector<uint8_t>& bytes, const T& value)
+    {
+        auto uValue = reinterpret_cast<const uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + sizeof(T));
+        return sizeof(T);
+    }
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, float value) { return serialize_raw(bytes, value); }
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, double value) { return serialize_raw(bytes, value); }
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, int8_t value) { return serialize_raw(bytes, value); }
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, uint8_t value) { return serialize_raw(bytes, value); }
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, int16_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap16(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 2u);
+        return 2u;
+    }
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, uint16_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap16(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 2u);
+        return 2u;
+    }
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, int32_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap32(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 4u);
+        return 4u;
+    }
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, uint32_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap32(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 4u);
+        return 4u;
+    }
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, int64_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap64(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 8u);
+        return 8u;
+    }
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, uint64_t value)
+    {
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap64(value);
+#endif
+        auto uValue = reinterpret_cast<uint8_t*>(&value);
+        bytes.insert(bytes.end(), uValue, uValue + 8u);
+        return 8u;
+    }
+
+    // ----- Basic unserializations
+
+    template <class T>
+    inline uint64_t unserialize_raw(T& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const T*>(uValue);
+        return sizeof(T);
+    }
+
+    inline uint64_t unserialize(float& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        return unserialize_raw(value, bytes, offset);
+    }
+    inline uint64_t unserialize(double& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        return unserialize_raw(value, bytes, offset);
+    }
+
+    inline uint64_t unserialize(int8_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        return unserialize_raw(value, bytes, offset);
+    }
+    inline uint64_t unserialize(uint8_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        return unserialize_raw(value, bytes, offset);
+    }
+
+    inline uint64_t unserialize(int16_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const int16_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap16(value);
+#endif
+        return 2u;
+    }
+    inline uint64_t unserialize(uint16_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const uint16_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap16(value);
+#endif
+        return 2u;
+    }
+
+    inline uint64_t unserialize(int32_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const int32_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap32(value);
+#endif
+        return 4u;
+    }
+    inline uint64_t unserialize(uint32_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const uint32_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap32(value);
+#endif
+        return 4u;
+    }
+
+    inline uint64_t unserialize(int64_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const int64_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap64(value);
+#endif
+        return 8u;
+    }
+    inline uint64_t unserialize(uint64_t& value, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        auto uValue = &bytes.at(offset);
+        value = *reinterpret_cast<const uint64_t*>(uValue);
+#if defined(__LINBOX_HAVE_BIG_ENDIAN)
+        value = __builtin_bswap64(value);
+#endif
+        return 8u;
+    }
+
+    // ----- Integer
+
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, const Integer& integer)
+    {
+        const __mpz_struct* mpzStruct = integer.get_mpz();
+
+        // We copy mpSize to a fixed-size variable
+        // to ensure compatibility between machines.
+        int32_t mpSize = mpzStruct->_mp_size;
+        auto bytesWritten = serialize(bytes, mpSize);
+
+        // @todo As said, we're not sure of how many bytes we will write here,
+        // because mp_limb_t can be either 32 or 64 bytes-long depending on configuration.
+        // This means it's not platform-independent yet.
+        for (auto i = 0, l = std::abs(mpSize); i < l; ++i) {
+            bytesWritten += serialize(bytes, mpzStruct->_mp_d[i]);
+        }
+
+        return bytesWritten;
+    }
+
+    inline uint64_t unserialize(Integer& integer, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        __mpz_struct* mpzStruct = integer.get_mpz();
+
+        int32_t mpSize;
+        uint32_t bytesRead = 0u;
+        bytesRead += unserialize(mpSize, bytes, offset + bytesRead);
+
+        mpzStruct->_mp_alloc = std::abs(mpSize);
+        mpzStruct->_mp_size = mpSize;
+        _mpz_realloc(mpzStruct, mpzStruct->_mp_alloc);
+
+        for (auto i = 0, l = std::abs(mpSize); i < l; ++i) {
+            bytesRead += unserialize(mpzStruct->_mp_d[i], bytes, offset + bytesRead);
+        }
+
+        return bytesRead;
+    }
+
+    // ----- BlasMatrix
+
+    template <class Field>
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, const BlasMatrix<Field>& M)
+    {
+        uint64_t n = M.rowdim(), m = M.coldim();
+        auto bytesWritten = serialize(bytes, n);
+        bytesWritten += serialize(bytes, m);
+
+        for (uint64_t i = 0; i < n; ++i) {
+            for (uint64_t j = 0; j < m; ++j) {
+                bytesWritten += serialize(bytes, M.getEntry(i, j));
+            }
+        }
+
+        return bytesWritten;
+    }
+
+    template <class Field>
+    inline uint64_t unserialize(BlasMatrix<Field>& M, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        uint64_t n, m;
+        uint64_t bytesRead = 0u;
+        bytesRead += unserialize(n, bytes, offset + bytesRead);
+        bytesRead += unserialize(m, bytes, offset + bytesRead);
+
+        M.resize(n, m);
+        for (uint64_t i = 0; i < n; ++i) {
+            for (uint64_t j = 0; j < m; ++j) {
+                typename Field::Element entry;
+                bytesRead += unserialize(entry, bytes, offset + bytesRead);
+                M.setEntry(i, j, entry);
+            }
+        }
+
+        return bytesRead;
+    }
+
+
+    // ----- SparseMatrix
+
+    template <class Field>
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, const SparseMatrix<Field>& M)
+    {
+        const auto& F = M.field();
+        uint64_t n = M.rowdim(), m = M.coldim(), size = M.size();
+        auto bytesWritten = serialize(bytes, n);
+        bytesWritten += serialize(bytes, m);
+        bytesWritten += serialize(bytes, size);
+
+        for (uint64_t i = 0; i < n; ++i) {
+            for (uint64_t j = 0; j < m; ++j) {
+                const auto& entry = M.getEntry(i, j);
+                if (!F.isZero(entry)) {
+                    bytesWritten += serialize(bytes, i);
+                    bytesWritten += serialize(bytes, j);
+                    bytesWritten += serialize(bytes, entry);
+                }
+            }
+        }
+
+        return bytesWritten;
+    }
+
+    template <class Field>
+    inline uint64_t unserialize(SparseMatrix<Field>& M, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        uint64_t n, m, size;
+        uint64_t bytesRead = 0u;
+        bytesRead += unserialize(n, bytes, offset + bytesRead);
+        bytesRead += unserialize(m, bytes, offset + bytesRead);
+        bytesRead += unserialize(size, bytes, offset + bytesRead);
+
+        M.resize(n, m);
+        for (uint64_t s = 0; s < size; ++s) {
+            uint64_t i, j;
+            bytesRead += unserialize(i, bytes, offset + bytesRead);
+            bytesRead += unserialize(j, bytes, offset + bytesRead);
+
+            typename Field::Element entry;
+            bytesRead += unserialize(entry, bytes, offset + bytesRead);
+            M.setEntry(i, j, entry);
+        }
+
+        return bytesRead;
+    }
+
+
+    // ----- BlasVector
+
+    template <class Field>
+    inline uint64_t serialize(std::vector<uint8_t>& bytes, const BlasVector<Field>& V)
+    {
+        uint64_t l = V.size();
+        auto bytesWritten = serialize(bytes, l);
+
+        for (uint64_t i = 0; i < l; ++i) {
+            bytesWritten += serialize(bytes, V[i]);
+        }
+
+        return bytesWritten;
+    }
+
+    template <class Field>
+    inline uint64_t unserialize(BlasVector<Field>& V, const std::vector<uint8_t>& bytes, uint64_t offset)
+    {
+        uint64_t l;
+        uint64_t bytesRead = 0u;
+        bytesRead += unserialize(l, bytes, offset + bytesRead);
+
+        V.resize(l);
+        for (uint64_t i = 0; i < l; ++i) {
+            bytesRead += unserialize(V[i], bytes, offset + bytesRead);
+        }
+
+        return bytesRead;
+    }
+}

--- a/tests/test-serialization.C
+++ b/tests/test-serialization.C
@@ -1,0 +1,226 @@
+/**
+* Copyright (C) LinBox
+*
+* ========LICENCE========
+* This file is part of the library LinBox.
+*
+* LinBox is free software: you can redistribute it and/or modify
+* it under the terms of the  GNU Lesser General Public
+* License as published by the Free Software Foundation; either
+* version 2.1 of the License, or (at your option) any later version.
+*
+* This library is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this library; if not, write to the Free Software
+* Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+* ========LICENCE========
+*/
+
+/**
+ * This is testing the serialization routines,
+ * by serializing, then unserializing and checking equality.
+ *
+ * Basic types (integer and floating points) are checked first.
+ * Custom LinBox classes (BlasMatrix, SparseMatrix, ...) are checked too.
+ */
+
+#include "linbox/matrix/random-matrix.h"
+#include "linbox/util/serialization.h"
+
+using namespace LinBox;
+
+template <class T>
+bool test(T& output, const T& input)
+{
+    // The vector of bytes that will store the serialized input
+    // is created with a certain size of uninitialized data.
+    // This is used to check that the unserialized does
+    // understand the offset start.
+    uint64_t randomOffset = rand() % 100;
+    std::vector<uint8_t> bytes(randomOffset);
+
+    auto bytesWritten = serialize(bytes, input);
+    if (bytesWritten == 0u) {
+        return false;
+    }
+
+    auto bytesRead = unserialize(output, bytes, randomOffset);
+    if (bytesRead != bytesWritten) {
+        return false;
+    }
+
+    return true;
+}
+
+template <class T>
+bool check_basic_type(const T& input)
+{
+    T output;
+    if (!test(output, input)) {
+        return false;
+    }
+
+    if (output != input) {
+        return false;
+    }
+
+    return true;
+}
+
+template <class T>
+bool test_basic_type()
+{
+    // @note This little trick is to ensure that 64 bits type
+    // have not just their lower bits written.
+    T input = rand();
+    input *= rand();
+    input += rand();
+
+    return check_basic_type(input);
+}
+
+bool test_integer()
+{
+    // Generating a big integer to ensure it is spreading over multiple limbs.
+    Integer input(1);
+    for (int i = 0; i < 20; ++i) {
+        input *= (1 + rand());
+    }
+    input += rand();
+
+    return check_basic_type(input);
+}
+
+// Check matrix equality after serialize/unserialize.
+template <class Field, class Matrix>
+bool check_matrix(const Field& F, const Matrix& input)
+{
+    Matrix output(F);
+
+    if (!test(output, input)) {
+        return false;
+    }
+
+    if (output.rowdim() != input.rowdim() || output.coldim() != input.coldim()) {
+        return false;
+    }
+
+    for (auto i = 0u; i < input.rowdim(); i++) {
+        for (auto j = 0u; j < input.coldim(); j++) {
+            if (!F.areEqual(input.getEntry(i, j), output.getEntry(i, j))) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+// Check vector equality after serialize/unserialize.
+template <class Field, class Vector>
+bool check_vector(const Field& F, const Vector& input)
+{
+    Vector output(F);
+
+    if (!test(output, input)) {
+        return false;
+    }
+
+    if (output.size() != input.size()) {
+        return false;
+    }
+
+    for (auto i = 0u; i < input.size(); i++) {
+        if (!F.areEqual(input[i], output[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// Tests serialibility of matrices and vectors of specified field elements.
+template <class Field>
+bool test_field(const Integer& q)
+{
+    // --- Test dense matrix
+
+    Field F(q); // Mersenne M31
+    BlasMatrix<Field> denseMatrix(F, 10 + rand() % 100, 10 + rand() % 100);
+
+    // Fill denseMatrix with random values!
+    typename Field::RandIter R(F);
+    RandomDenseMatrix<typename Field::RandIter, Field> RandMat(F, R);
+    RandMat.random(denseMatrix);
+
+    check_matrix(F, denseMatrix);
+
+    // --- Test sparse matrix
+
+    SparseMatrix<Field> sparseMatrix(F, denseMatrix.rowdim(), denseMatrix.coldim());
+    for (auto i = 0u; i < denseMatrix.rowdim(); i++) {
+        for (auto j = 0u; j < denseMatrix.coldim(); j++) {
+            if (rand() % 2 == 0) {
+                sparseMatrix.setEntry(i, j, denseMatrix.getEntry(i, j));
+            }
+        }
+    }
+
+    check_matrix(F, sparseMatrix);
+
+    // --- Test dense vector
+
+    BlasVector<Field> denseVector(F, denseMatrix.rowdim(), denseMatrix.coldim());
+    for (auto i = 0u; i < denseMatrix.rowdim(); i++) {
+        denseVector[i] = denseMatrix.getEntry(i, 0);
+    }
+
+    check_vector(F, denseVector);
+
+    return true;
+}
+
+int main(int argc, char** argv)
+{
+    Integer q = 2147483647;
+    uint64_t seed = time(nullptr);
+    bool loop = false;
+
+    Argument as[] = {{'q', "-q Q", "Set the field characteristic (-1 for random).", TYPE_INTEGER, &q},
+                     {'s', "-s seed", "Set seed for the random generator", TYPE_UINT64, &seed},
+                     {'l', "-loop Y/N", "run the test in an infinite loop.", TYPE_BOOL, &loop},
+                     END_OF_ARGUMENTS};
+
+    FFLAS::parseArguments(argc, argv, as);
+
+    srand(seed);
+
+    bool ok = true;
+    do {
+        auto lastKnownSeed = seed;
+        ok = ok && test_basic_type<int8_t>();
+        ok = ok && test_basic_type<uint8_t>();
+        ok = ok && test_basic_type<int16_t>();
+        ok = ok && test_basic_type<uint16_t>();
+        ok = ok && test_basic_type<int32_t>();
+        ok = ok && test_basic_type<uint32_t>();
+        ok = ok && test_basic_type<int64_t>();
+        ok = ok && test_basic_type<uint64_t>();
+        ok = ok && test_basic_type<float>();
+        ok = ok && test_basic_type<double>();
+
+        ok = ok && test_integer();
+
+        ok = ok && test_field<Givaro::ZRing<Integer>>(q);
+        ok = ok && test_field<Givaro::Modular<float>>(q);
+        ok = ok && test_field<Givaro::Modular<double>>(q);
+
+        if (!ok) std::cerr << "Failed with seed: " << lastKnownSeed << std::endl;
+    } while (loop && ok);
+
+    return !ok;
+}

--- a/tests/test-serialization.C
+++ b/tests/test-serialization.C
@@ -149,7 +149,7 @@ bool test_field(const Integer& q)
 {
     // --- Test dense matrix
 
-    Field F(q); // Mersenne M31
+    Field F(q);
     BlasMatrix<Field> denseMatrix(F, 10 + rand() % 100, 10 + rand() % 100);
 
     // Fill denseMatrix with random values!


### PR DESCRIPTION
The PR implements platform-independent serialization with associated tests.

The functions `uint64_t serialize(std::vector<uint8_t>& bytes, const T& value);` converts the value to bytes and add those to the specified vector, they return the number of bytes written. The counter part `unserialize` is implemented too.

Tricky cases implemented:
- Enforcing little-endian serialization, so there is a little bit more work to do on big-endian machines;
- `Integer` are nicely serialized (using the underlying mpz_struct);
- `BlasMatrix`, `SparseMatrix` and `BlasVector` can be serialized, as long as the underlying `Field::Element` is serializable.

Upcoming use cases:
- MPI communication requires endianness-resistant routines to transfer LinBox matrices or vectors. This PR also allows us to send only one message (currently a SparseMatrix requires 8 sendings!) as all data is stored in one vector.
- We might want a binary file specification that is able to store matrices with GMP integers.