### PR TITLE
Replace unsigned long to size_t

### DIFF
--- a/linbox/algorithms/bbcharpoly.h
+++ b/linbox/algorithms/bbcharpoly.h
@@ -76,7 +76,7 @@ namespace LinBox
 				fieldP(NULL),intP(NULL)
 				,multiplicity(0),dep(NULL)
 			{}
-			FactorMult( FieldPoly* FP, IntPoly* IP, unsigned long m, FactorMult<FieldPoly,IntPoly>*d) :
+			FactorMult( FieldPoly* FP, IntPoly* IP, size_t m, FactorMult<FieldPoly,IntPoly>*d) :
 				fieldP(FP), intP(IP), multiplicity(m), dep(d)
 			{}
 
@@ -116,7 +116,7 @@ namespace LinBox
 
 			FieldPoly                       *fieldP;
 			IntPoly                         *intP;
-			unsigned long                   multiplicity;
+			size_t                   multiplicity;
 			FactorMult<FieldPoly, IntPoly>  *dep;
 
 			std::ostream& write(std::ostream& os)
@@ -163,7 +163,7 @@ namespace LinBox
 			typedef typename PolynomialRing<Field,Givaro::Dense>::Element FieldPoly;
 			// Set of factors-multiplicities sorted by degree
 			typedef FactorMult<FieldPoly,IntPoly> FM;
-			typedef std::multimap<unsigned long,FM*> FactPoly;
+			typedef std::multimap<size_t,FM*> FactPoly;
 			typedef typename FactPoly::iterator FactPolyIterator;
 			std::multimap<FM*,bool> leadingBlocks;
 			//typename std::multimap<FM*,bool>::iterator lead_it;
@@ -263,7 +263,7 @@ namespace LinBox
 			typedef PolynomialRing<Field, Givaro::Dense> PolyDom;
 			typedef typename PolyDom::Element FieldPoly;
 			// Set of factors-multiplicities sorted by degree
-			typedef std::multimap<unsigned long,FactorMult<FieldPoly>* > FactPoly;
+			typedef std::multimap<size_t,FactorMult<FieldPoly>* > FactPoly;
 			typedef typename FactPoly::iterator FactPolyIterator;
 			std::multimap<FactorMult<FieldPoly>*,bool> leadingBlocks;
 			//typename std::multimap<FactorMult<Polynomial>*,bool>::iterator lead_it;
@@ -367,12 +367,12 @@ namespace LinBox
 
 		template <class BlackBox, class FieldPoly, class IntPoly>
 		static void findMultiplicities( const BlackBox& A,
-					 std::multimap<unsigned long, FactorMult<FieldPoly,IntPoly>* >& factCharPoly,
+					 std::multimap<size_t, FactorMult<FieldPoly,IntPoly>* >& factCharPoly,
 					 std::multimap<FactorMult<FieldPoly,IntPoly>*,bool>& leadingBlocks,
 					 int goal,
 					 const Method::Blackbox &M)
 		{
-			typedef std::multimap<unsigned long, FactorMult<FieldPoly,IntPoly>* > FactPoly;
+			typedef std::multimap<size_t, FactorMult<FieldPoly,IntPoly>* > FactPoly;
 			typedef typename BlackBox::Field Field;
 			typedef PolynomialRing<Field, Givaro::Dense> PolyDom;
 			typename FactPoly::iterator itf = factCharPoly.begin();

--- a/linbox/algorithms/blackbox-container-base.h
+++ b/linbox/algorithms/blackbox-container-base.h
@@ -71,7 +71,7 @@ namespace LinBox
 
 		// Pascal Giorgi 16.02.2004
 		//! @bug no need for F
-		BlackboxContainerBase (const Blackbox *BB, const Field &F, unsigned long Size) :
+		BlackboxContainerBase (const Blackbox *BB, const Field &F, size_t Size) :
 			_field (&F), _VD (F), _BB (BB), _size ((long)Size)
 			,casenumber(0)
 			,u(F),v(F)

--- a/linbox/algorithms/blackbox-container.h
+++ b/linbox/algorithms/blackbox-container.h
@@ -59,7 +59,7 @@ namespace LinBox
 
 		// Pascal Giorgi 16.02.2004
 		template<class Vector>
-		BlackboxContainer(const Blackbox * D, const Field &F, const Vector &u0, unsigned long size) :
+		BlackboxContainer(const Blackbox * D, const Field &F, const Vector &u0, size_t size) :
 			BlackboxContainerBase<Field, Blackbox> (D, F,size)
 			,w(F)
 		{

--- a/linbox/algorithms/block-coppersmith-domain.h
+++ b/linbox/algorithms/block-coppersmith-domain.h
@@ -80,18 +80,18 @@ namespace LinBox
     protected:
         Sequence                          *_container;
         const Domain                      *_MD;
-        unsigned long            EARLY_TERM_THRESHOLD;
+        size_t            EARLY_TERM_THRESHOLD;
 
 
     public:
 
         BlockCoppersmithDomain (const BlockCoppersmithDomain<Field,
-Sequence> &Mat, unsigned long ett_default =
+Sequence> &Mat, size_t ett_default =
 DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
             _container(Mat._container), _MD(Mat._MD),
             EARLY_TERM_THRESHOLD (ett_default)
         {}
-        BlockCoppersmithDomain (const Domain& MD, Sequence *D, unsigned long ett_default
+        BlockCoppersmithDomain (const Domain& MD, Sequence *D, size_t ett_default
 = DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
             _container(D), _MD(&MD),
 EARLY_TERM_THRESHOLD (ett_default)
@@ -330,7 +330,7 @@ EARLY_TERM_THRESHOLD (ett_default)
 			inline const Field &field() const { return domain().field();}
 			//Constructor
 			explicit BM_iterator(BM_Seq& s,
-                                             unsigned long earlyTermThreshold=DEFAULT_BLOCK_EARLY_TERM_THRESHOLD,
+                                             size_t earlyTermThreshold=DEFAULT_BLOCK_EARLY_TERM_THRESHOLD,
                                              typename BM_Seq::size_type elinit=0) :
 				 _MD(&s.domain()),  _seq(s)
 			{

--- a/linbox/algorithms/block-massey-domain.h
+++ b/linbox/algorithms/block-massey-domain.h
@@ -109,7 +109,7 @@ namespace LinBox
 		const Field                           *_field;
 		BlasMatrixDomain<Field>                  _BMD;
 		MatrixDomain<Field>                       _MD;
-		unsigned long            EARLY_TERM_THRESHOLD;
+		size_t            EARLY_TERM_THRESHOLD;
 
 
 	public:
@@ -189,7 +189,7 @@ namespace LinBox
 #endif
 
 
-		BlockMasseyDomain (const BlockMasseyDomain<Field, Sequence> &Mat, unsigned long ett_default = DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
+		BlockMasseyDomain (const BlockMasseyDomain<Field, Sequence> &Mat, size_t ett_default = DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
 			_container(Mat._container), _field(Mat._field), _BMD(Mat.field()),
 			_MD(Mat.field()),  EARLY_TERM_THRESHOLD (ett_default)
 		{
@@ -199,7 +199,7 @@ namespace LinBox
 
 		}
 
-		BlockMasseyDomain (Sequence *D, unsigned long ett_default = DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
+		BlockMasseyDomain (Sequence *D, size_t ett_default = DEFAULT_BLOCK_EARLY_TERM_THRESHOLD) :
 			_container(D), _field(&(D->field ())), _BMD(D->field ()), _MD(D->field ()), EARLY_TERM_THRESHOLD (ett_default)
 		{
 #ifdef _BM_TIMING
@@ -300,7 +300,7 @@ namespace LinBox
 			if (_BMD.rank(*_iter)< min_mn)
 				throw PreconditionFailed (__func__, __LINE__, "Bad random Blocks, abort\n");
 
-			unsigned long early_stop=0;
+			size_t early_stop=0;
 			long NN;
 			for (NN = 0; (NN < (long)length) && (early_stop < EARLY_TERM_THRESHOLD) ; ++NN, ++_iter) {
 

--- a/linbox/algorithms/classic-rational-reconstruction.h
+++ b/linbox/algorithms/classic-rational-reconstruction.h
@@ -263,7 +263,7 @@ namespace LinBox
 				Element T = (uint32_t) m.bitsize();
 				int c = 5;	//should be changed here to enhance probability of correctness
 
-				while((a>0) && (r0.bitsize() > T.bitsize() + (unsigned long)c))
+				while((a>0) && (r0.bitsize() > T.bitsize() + (size_t)c))
 				{
 					q = r0;
 					_intRing.divin(q,a);        // r0/num
@@ -272,7 +272,7 @@ namespace LinBox
 						amax = a;
 						bmax = b;
 						qmax = q;
-						if (qmax.bitsize() > T.bitsize() + (unsigned long)c) break;
+						if (qmax.bitsize() > T.bitsize() + (size_t)c) break;
 					}
 
 					u = a;
@@ -307,7 +307,7 @@ namespace LinBox
 				//Element T = m.bitsize();
 				//int c = 20;
 				//T=0;c=0;
-				if (qmax.bitsize() > T.bitsize() + (unsigned long)c) {
+				if (qmax.bitsize() > T.bitsize() + (size_t)c) {
 					return true;
 				}
 				else return false;

--- a/linbox/algorithms/cra-early-multip.h
+++ b/linbox/algorithms/cra-early-multip.h
@@ -57,12 +57,12 @@ namespace LinBox
 	protected:
 		// Random coefficients for a linear combination
 		// of the elements to be reconstructed
-		std::vector< unsigned long >      	randv;
+		std::vector< size_t >      	randv;
 
 		Integer& result(Integer &d) { std::cout << "should not be called" << std::endl; return d ;} ; // DON'T TOUCH
 	public:
 
-		EarlyMultipCRA(const unsigned long EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
+		EarlyMultipCRA(const size_t EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
 			EarlySingleCRA<Domain>(EARLY), FullMultipCRA<Domain>()
 		{}
 
@@ -90,8 +90,8 @@ namespace LinBox
 		{
 			srand48(BaseTimer::seed());
 			randv. resize ( e.size() );
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+			for ( std::vector<size_t>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
+				*int_p = ((size_t)lrand48()) % 20000;
 			Integer z;
 			dot(z, D, e, randv);
 			EarlySingleCRA<Domain>::initialize(D, z);
@@ -106,9 +106,9 @@ namespace LinBox
 			// of the elements to be reconstructed
 			srand48(BaseTimer::seed());
 			randv. resize ( e.size() );
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();
+			for ( std::vector<size_t>::iterator int_p = randv. begin();
 			      int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+				*int_p = ((size_t)lrand48()) % 20000;
 			DomainElement z;
 			// Could be much faster
 			// - do not compute twice the product of moduli
@@ -125,9 +125,9 @@ namespace LinBox
 			// of the elements to be reconstructed
 			srand48(BaseTimer::seed());
 			randv. resize ( e.size() );
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();
+			for ( std::vector<size_t>::iterator int_p = randv. begin();
 			      int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+				*int_p = ((size_t)lrand48()) % 20000;
 			DomainElement z;
 			// Could be much faster
 			// - do not compute twice the product of moduli
@@ -203,8 +203,8 @@ namespace LinBox
 
 		bool changeVector()
 		{
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+			for ( std::vector<size_t>::iterator int_p = randv. begin();int_p != randv. end(); ++ int_p)
+				*int_p = ((size_t)lrand48()) % 20000;
 
 			std::vector<Integer> e(randv.size());
 			/* clear CRAEarlySingle; */

--- a/linbox/algorithms/cra-single.h
+++ b/linbox/algorithms/cra-single.h
@@ -382,7 +382,7 @@ namespace LinBox
 		 *
 		 * @param	EARLY how many unchanging iterations until termination.
 		 */
-		EarlySingleCRA(const unsigned long EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
+		EarlySingleCRA(const size_t EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
 			EARLY_TERM_THRESHOLD((unsigned)EARLY-1),
 			occurency_(0U)
 		{ }

--- a/linbox/algorithms/frobenius-large.h
+++ b/linbox/algorithms/frobenius-large.h
@@ -93,7 +93,7 @@ public:
 		MasseyDomain<Field, Sequence> MasseyDom(&seq, 20);
 		
 		BlasVector<Field> phi(_F);
-		unsigned long deg;
+		size_t deg;
 		MasseyDom.minpoly(phi, deg);
 		
 		_R.init(g, phi);

--- a/linbox/algorithms/frobenius-small.h
+++ b/linbox/algorithms/frobenius-small.h
@@ -173,7 +173,7 @@ protected:
 		MasseyDomain<Field, Sequence> WD(&seq, 20);
 		
 		BlasVector<Field> phi(_F);
-		unsigned long deg;
+		size_t deg;
 		WD.minpoly(phi, deg);
 		
 		_R.init(f, phi);

--- a/linbox/algorithms/gauss-gf2.h
+++ b/linbox/algorithms/gauss-gf2.h
@@ -80,26 +80,26 @@ namespace LinBox
 		//@{
 		///
 		///
-		template <class SparseSeqMatrix> unsigned long& rankin(unsigned long &Rank,
+		template <class SparseSeqMatrix> size_t& rankin(size_t &Rank,
 		SparseSeqMatrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const ;
 
 		///
-		template <class SparseSeqMatrix> unsigned long& rankin(unsigned long &Rank,
+		template <class SparseSeqMatrix> size_t& rankin(size_t &Rank,
 		SparseSeqMatrix        &A,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 
 		///
-		template <class SparseSeqMatrix> unsigned long& rank(unsigned long &rk,
+		template <class SparseSeqMatrix> size_t& rank(size_t &rk,
 		const SparseSeqMatrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const ;
 
 		///
-		template <class SparseSeqMatrix> unsigned long& rank(unsigned long &rk,
+		template <class SparseSeqMatrix> size_t& rank(size_t &rk,
 		const SparseSeqMatrix        &A,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const ;
 
@@ -120,8 +120,8 @@ namespace LinBox
 		///
 		template <class SparseSeqMatrix> Element& detin(Element &determinant,
 		SparseSeqMatrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		///
 		template <class SparseSeqMatrix> Element& det(Element &determinant,
@@ -130,8 +130,8 @@ namespace LinBox
 		///
 		template <class SparseSeqMatrix> Element& det(Element &determinant,
 		const SparseSeqMatrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		//@}
 
@@ -154,17 +154,17 @@ namespace LinBox
 		 * In Ganzha et~al. CASC'2002, pages 47--62.
 		 */
 		template <class SparseSeqMatrix, class Perm>
-		unsigned long& QLUPin(unsigned long &Rank,
+		size_t& QLUPin(size_t &Rank,
 				      Element& determinant,
 				      Perm          &Q,
 				      SparseSeqMatrix	    &L,
 				      SparseSeqMatrix        &U,
 				      Perm	    &P,
-				      unsigned long Ni,
-				      unsigned long Nj) const;
+				      size_t Ni,
+				      size_t Nj) const;
 
 		template <class SparseSeqMatrix, class Perm, class Vector1, class Vector2>
-		Vector1& solve(Vector1& x, Vector1& w, unsigned long Rank, const Perm& Q, const SparseSeqMatrix& L, const SparseSeqMatrix& U, const Perm& P, const Vector2& b) const;
+		Vector1& solve(Vector1& x, Vector1& w, size_t Rank, const Perm& Q, const SparseSeqMatrix& L, const SparseSeqMatrix& U, const Perm& P, const Vector2& b) const;
 
 
 		template <class SparseSeqMatrix, class Vector1, class Vector2>
@@ -179,14 +179,14 @@ namespace LinBox
 
 
 		template <class SparseSeqMatrix, class Perm>
-		unsigned long& InPlaceLinearPivoting(unsigned long &Rank,
+		size_t& InPlaceLinearPivoting(size_t &Rank,
 						     Element& determinant,
 						     SparseSeqMatrix        &A,
 						     Perm                   &P,
-						     unsigned long Ni,
-						     unsigned long Nj) const;
+						     size_t Ni,
+						     size_t Nj) const;
 		template <class SparseSeqMatrix>
-		unsigned long& NoReordering (unsigned long & Rank, Element& , SparseSeqMatrix &, unsigned long , unsigned long ) const
+		size_t& NoReordering (size_t & Rank, Element& , SparseSeqMatrix &, size_t , size_t ) const
 		{
 			std::cerr << "Sparse elimination over GF2 without reordering not implemented" << std::endl;
 			return Rank;
@@ -206,14 +206,14 @@ namespace LinBox
 		void eliminateBinary (Element             & headpivot,
 				      Vector              &lignecourante,
 				      const Vector        &lignepivot,
-				      const unsigned long indcol,
+				      const size_t indcol,
 				      const long indpermut,
-				      const unsigned long npiv,
+				      const size_t npiv,
 				      D                   &columns) const;
 
 		template <class Vector>
 		void permuteBinary (Vector              &lignecourante,
-				    const unsigned long &indcol,
+				    const size_t &indcol,
 				    const long &indpermut) const;
 
 		//------------------------------------------
@@ -224,14 +224,14 @@ namespace LinBox
 		// 2. Column density is minimum for this row
 		//------------------------------------------
 		template <class Vector, class D>
-		void SparseFindPivotBinary (Vector &lignepivot, unsigned long &indcol, long &indpermut, D &columns, Element& determinant) const;
+		void SparseFindPivotBinary (Vector &lignepivot, size_t &indcol, long &indpermut, D &columns, Element& determinant) const;
 
 		//------------------------------------------
 		// Looking for a non-zero pivot in a row
 		// No reordering
 		//------------------------------------------
 		template <class Vector>
-		void SparseFindPivotBinary (Vector &lignepivot, unsigned long &indcol, long &indpermut, Element& determinant) const;
+		void SparseFindPivotBinary (Vector &lignepivot, size_t &indcol, long &indpermut, Element& determinant) const;
 
 	};
 } // namespace LinBox

--- a/linbox/algorithms/gauss.h
+++ b/linbox/algorithms/gauss.h
@@ -105,24 +105,24 @@ namespace LinBox
 		  */
 		//@{
 		///
-		template <class _Matrix> unsigned long& rankin(unsigned long &rank,
+		template <class _Matrix> size_t& rankin(size_t &rank,
 							      _Matrix        &A,
 							      SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		///
-		template <class _Matrix> unsigned long& rankin(unsigned long &rank,
+		template <class _Matrix> size_t& rankin(size_t &rank,
 		_Matrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		///
-		template <class _Matrix> unsigned long& rank(unsigned long &rank,
+		template <class _Matrix> size_t& rank(size_t &rank,
 		const _Matrix        &A,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		///
-		template <class _Matrix> unsigned long& rank(unsigned long &rank,
+		template <class _Matrix> size_t& rank(size_t &rank,
 		const _Matrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		//@}
 
@@ -141,8 +141,8 @@ namespace LinBox
 		///
 		template <class _Matrix> Element& detin(Element &determinant,
 		_Matrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		///
 		template <class _Matrix> Element& det(Element &determinant,
@@ -151,8 +151,8 @@ namespace LinBox
 		///
 		template <class _Matrix> Element& det(Element &determinant,
 		const _Matrix        &A,
-		unsigned long  Ni,
-		unsigned long  Nj,
+		size_t  Ni,
+		size_t  Nj,
 		SparseEliminationTraits::PivotStrategy   reord = SparseEliminationTraits::PIVOT_LINEAR) const;
 		//@}
 
@@ -175,27 +175,27 @@ namespace LinBox
 		 * In Ganzha et~al. CASC'2002, pages 47--62.
 		 */
 		template <class _Matrix, class Perm>
-		unsigned long& QLUPin(unsigned long &rank,
+		size_t& QLUPin(size_t &rank,
 				      Element& determinant,
 				      Perm          &Q,
 				      _Matrix	    &L,
 				      _Matrix        &U,
 				      Perm	    &P,
-				      unsigned long Ni,
-				      unsigned long Nj) const;
+				      size_t Ni,
+				      size_t Nj) const;
 
 		template <class _Matrix, class Perm>
-		unsigned long& DenseQLUPin(unsigned long &rank,
+		size_t& DenseQLUPin(size_t &rank,
 				      Element& determinant,
 				      std::deque<std::pair<size_t,size_t> > &invQ,
 				      _Matrix	    &L,
 				      _Matrix        &U,
 				      Perm	    &P,
-				      unsigned long Ni,
-				      unsigned long Nj) const;
+				      size_t Ni,
+				      size_t Nj) const;
 
 		template <class _Matrix, class Perm, class Vector1, class Vector2>
-		Vector1& solve(Vector1& x, Vector1& w, unsigned long rank, const Perm& Q, const _Matrix& L, const _Matrix& U, const Perm& P, const Vector2& b)  const;
+		Vector1& solve(Vector1& x, Vector1& w, size_t rank, const Perm& Q, const _Matrix& L, const _Matrix& U, const Perm& P, const Vector2& b)  const;
 
 
 		template <class _Matrix, class Vector1, class Vector2>
@@ -211,7 +211,7 @@ namespace LinBox
 
 		template <class _Matrix, class Perm, class Block>
 		Block& nullspacebasis(Block& x,
-				      unsigned long rank,
+				      size_t rank,
 				      const _Matrix& U,
 				      const Perm& P)  const ;
 
@@ -225,22 +225,22 @@ namespace LinBox
 		// Sparsest method
 		//   erases elements while computing rank/det.
 		template <class _Matrix>
-		unsigned long& InPlaceLinearPivoting(unsigned long &rank,
+		size_t& InPlaceLinearPivoting(size_t &rank,
 						     Element& determinant,
 						     _Matrix        &A,
-						     unsigned long Ni,
-						     unsigned long Nj) const;
+						     size_t Ni,
+						     size_t Nj) const;
 
 		// Same as the latter but keeps trace
 		//   of column permutations
 		//   of remaining elements in the matrix
 		template <class _Matrix,class Perm>
-		unsigned long& InPlaceLinearPivoting(unsigned long &rank,
+		size_t& InPlaceLinearPivoting(size_t &rank,
 						     Element& determinant,
 						     _Matrix        &A,
 						     Perm          &P,
-						     unsigned long Ni,
-						     unsigned long Nj) const;
+						     size_t Ni,
+						     size_t Nj) const;
 
 
 		/** \brief Sparse Gaussian elimination without reordering.
@@ -255,14 +255,14 @@ Without reordering (Pivot is first non-zero in row)
 
 */
 		template <class _Matrix>
-		unsigned long& NoReordering (unsigned long &rank, Element& determinant, _Matrix &LigneA, unsigned long Ni, unsigned long Nj) const;
+		size_t& NoReordering (size_t &rank, Element& determinant, _Matrix &LigneA, size_t Ni, size_t Nj) const;
 
 		/** \brief Dense in place LU factorization without reordering
 
 Using : FindPivot and LU
 */
 		template <class _Matrix>
-		unsigned long &LUin (unsigned long &rank, _Matrix &A) const;
+		size_t &LUin (size_t &rank, _Matrix &A) const;
 
 
 		/** \brief Dense in place Gaussian elimination without reordering
@@ -270,7 +270,7 @@ Using : FindPivot and LU
 Using : FindPivot and LU
 */
 		template <class _Matrix>
-		unsigned long &upperin (unsigned long &rank, _Matrix &A) const;
+		size_t &upperin (size_t &rank, _Matrix &A) const;
 
 
 
@@ -287,21 +287,21 @@ Using : FindPivot and LU
 		void eliminate (Element             & headpivot,
 				Vector              &lignecourante,
 				const Vector        &lignepivot,
-				const unsigned long indcol,
+				const size_t indcol,
 				const long indpermut,
-				const unsigned long npiv,
+				const size_t npiv,
 				D                   &columns) const;
 
 		template <class Vector, class D>
 		void eliminate (Vector              &lignecourante,
 				const Vector        &lignepivot,
-				const unsigned long &indcol,
+				const size_t &indcol,
 				const long &indpermut,
 				D                   &columns) const;
 
 		template <class Vector>
 		void permute (Vector              &lignecourante,
-			      const unsigned long &indcol,
+			      const size_t &indcol,
 			      const long &indpermut) const;
 		//-----------------------------------------
 		// Sparse elimination using a pivot row :
@@ -312,7 +312,7 @@ Using : FindPivot and LU
 		template <class Vector>
 		void eliminate (Vector              &lignecourante,
 				const Vector        &lignepivot,
-				const unsigned long &indcol,
+				const size_t &indcol,
 				const long &indpermut) const;
 
 		//-----------------------------------------
@@ -323,7 +323,7 @@ Using : FindPivot and LU
 		template<class Vector>
 		void Upper (Vector       &lignecur,
 			    const Vector &lignepivot,
-			    unsigned long indcol,
+			    size_t indcol,
 			    long indpermut) const;
 
 		//-----------------------------------------
@@ -333,7 +333,7 @@ Using : FindPivot and LU
 		template <class Vector>
 		void LU (Vector       &lignecur,
 			 const Vector &lignepivot,
-			 unsigned long indcol,
+			 size_t indcol,
 			 long indpermut) const;
 
 		//------------------------------------------
@@ -344,44 +344,44 @@ Using : FindPivot and LU
 		// 2. Column density is minimum for this row
 		//------------------------------------------
 		template <class Vector, class D>
-		void SparseFindPivot (Vector &lignepivot, unsigned long &indcol, long &indpermut, D &columns, Element& determinant) const;
+		void SparseFindPivot (Vector &lignepivot, size_t &indcol, long &indpermut, D &columns, Element& determinant) const;
 
 		//------------------------------------------
 		// Looking for a non-zero pivot in a row
 		// No reordering
 		//------------------------------------------
 		template <class Vector>
-		void SparseFindPivot (Vector &lignepivot, unsigned long &indcol, long &indpermut, Element& determinant) const;
+		void SparseFindPivot (Vector &lignepivot, size_t &indcol, long &indpermut, Element& determinant) const;
 
 		//------------------------------------------
 		// Looking for a non-zero pivot in a row
 		// Dense search
 		//------------------------------------------
 		template <class Vector>
-		void FindPivot (Vector &lignepivot, unsigned long &k, long &indpermut) const;
+		void FindPivot (Vector &lignepivot, size_t &k, long &indpermut) const;
 
 		template <class _Matrix, class Perm>
-		unsigned long& SparseContinuation(unsigned long &rank,
+		size_t& SparseContinuation(size_t &rank,
 				      Element& determinant,
 				      std::deque<std::pair<size_t,size_t> > &invQ,
 				      _Matrix	&L,
 				      _Matrix	&U,
 				      Perm	    &P,
-				      unsigned long Ni,
-				      unsigned long Nj) const;
+				      size_t Ni,
+				      size_t Nj) const;
 
         
 		template <class _Matrix, class Perm, bool hasFFLAS>
         struct Continuation {
-            unsigned long& operator()(
-                unsigned long &rank,
+            size_t& operator()(
+                size_t &rank,
                 Element& determinant,
                 std::deque<std::pair<size_t,size_t> > &invQ,
                 _Matrix	    &L,
                 _Matrix		&U,
                 Perm	    &P,
-                unsigned long Ni,
-                unsigned long Nj, bool) const;
+                size_t Ni,
+                size_t Nj, bool) const;
         };
 	};
 

--- a/linbox/algorithms/gauss/gauss-det-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-det-gf2.inl
@@ -33,11 +33,11 @@ namespace LinBox
 	template <class SparseSeqMatrix> inline typename GaussDomain<GF2>::Element&
 	GaussDomain<GF2>::detin(Element		&determinant,
                                 SparseSeqMatrix        	&A,
-                                unsigned long  	Ni,
-                                unsigned long  	Nj,
+                                size_t  	Ni,
+                                size_t  	Nj,
                                 SparseEliminationTraits::PivotStrategy   reord)  const
 	{
-		unsigned long Rank;
+		size_t Rank;
 		if (reord == SparseEliminationTraits::PIVOT_NONE)
 			NoReordering(Rank, determinant, A, Ni, Nj);
 		else {
@@ -69,12 +69,12 @@ namespace LinBox
 	template <class SparseSeqMatrix> inline typename GaussDomain<GF2>::Element&
 	GaussDomain<GF2>::det(Element       &determinant,
                               const SparseSeqMatrix  &A,
-                              unsigned long  Ni,
-                              unsigned long  Nj,
+                              size_t  Ni,
+                              size_t  Nj,
                               SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		SparseSeqMatrix CopyA(Ni);
-		for(unsigned long i = 0; i < Ni; ++i)
+		for(size_t i = 0; i < Ni; ++i)
 			CopyA[i] = A[i];
 		return detin(determinant, CopyA, Ni, Nj, reord);
 	}

--- a/linbox/algorithms/gauss/gauss-det.inl
+++ b/linbox/algorithms/gauss/gauss-det.inl
@@ -34,11 +34,11 @@ namespace LinBox
 	template <class _Matrix> inline typename GaussDomain<_Field>::Element&
 	GaussDomain<_Field>::detin(Element        &determinant,
 				   _Matrix        &A,
-				   unsigned long  Ni,
-				   unsigned long  Nj,
+				   size_t  Ni,
+				   size_t  Nj,
 				   SparseEliminationTraits::PivotStrategy   reord)  const
 	{
-		unsigned long Rank;
+		size_t Rank;
 		if (reord == SparseEliminationTraits::PIVOT_NONE)
 			NoReordering(Rank, determinant, A,  Ni, Nj);
 		else
@@ -71,12 +71,12 @@ namespace LinBox
 	template <class _Matrix> inline typename GaussDomain<_Field>::Element&
 	GaussDomain<_Field>::det(Element       &determinant,
 				 const _Matrix  &A,
-				 unsigned long  Ni,
-				 unsigned long  Nj,
+				 size_t  Ni,
+				 size_t  Nj,
 				 SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		_Matrix CopyA(Ni);
-		for(unsigned long i = 0; i < Ni; ++i)
+		for(size_t i = 0; i < Ni; ++i)
 			CopyA[i] = A[i];
 		return detin(determinant, CopyA, Ni, Nj, reord);
 	}

--- a/linbox/algorithms/gauss/gauss-elim-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-elim-gf2.inl
@@ -32,10 +32,10 @@ namespace LinBox
 {
 	template <class Vector> inline void
 	GaussDomain<GF2>::permuteBinary (Vector              &lignecourante,
-					 const unsigned long &indcol,
+					 const size_t &indcol,
 					 const long &indpermut) const
 	{
-		const unsigned long k = indcol - 1;
+		const size_t k = indcol - 1;
 
 #if 0
 		std::cerr << "B PERMUTE: " << indpermut << " <--> " << k << " of  [";
@@ -114,16 +114,16 @@ namespace LinBox
 	GaussDomain<GF2>::eliminateBinary (bool             &headpivot,
 					   Vector              &lignecourante,
 					   const Vector        &lignepivot,
-					   const unsigned long indcol,
+					   const size_t indcol,
 					   const long indpermut,
-					   const unsigned long npiv,
+					   const size_t npiv,
 					   D                   &columns) const
 	{
 
 		typedef typename Vector::value_type E;
 
-		unsigned long k = indcol - 1;
-		unsigned long nj = lignecourante.size () ;
+		size_t k = indcol - 1;
+		size_t nj = lignecourante.size () ;
 #if 0
 		std::cerr << "BEGIN ELIMINATE, k: " << k << ", nj: " << nj << ", indpermut: " << indpermut << ", indcol: " << indcol << std::endl;
 		std::cerr << "lignepivot: [";
@@ -139,7 +139,7 @@ namespace LinBox
 		std::cerr << ']' << std::endl;
 #endif
 		if (nj > 0) {
-			unsigned long j_head = 0;
+			size_t j_head = 0;
 
 			for (; j_head < nj; ++j_head) {
 				if (static_cast<long>(lignecourante[(size_t)j_head]) >= indpermut) break;
@@ -174,8 +174,8 @@ namespace LinBox
 					// construit : <-- j
 					// courante  : <-- m
 					// pivot     : <-- l
-					unsigned long j = 0;
-					unsigned long m = j_head + 1;
+					size_t j = 0;
+					size_t m = j_head + 1;
 
 					// A[i,k] <-- - A[i,k] / A[k,k]
 					headpivot = true;
@@ -188,14 +188,14 @@ namespace LinBox
 					}
 
 
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < npiv; ++l)
 						if (lignepivot[l] > k) break;
 
 					// for all j such that (j>k) and A[k,j]!=0
 					while (l < npiv) {
-					unsigned long j_piv;
+					size_t j_piv;
 						j_piv = lignepivot[l];
 
 						// if A[k,j]=0, then A[i,j] <-- A[i,j]
@@ -236,7 +236,7 @@ namespace LinBox
 #endif
 					if (indpermut != static_cast<long>(k)) {
 						if (j_head>0) {
-							unsigned long l = 0;
+							size_t l = 0;
 
 							for (; l < nj; ++l)
 								if (lignecourante[(size_t)l] >= k) break;
@@ -248,7 +248,7 @@ namespace LinBox
 								++columns[(size_t)indpermut];
 								tmp = (E)indpermut;
 
-								unsigned long bjh = j_head-1;
+								size_t bjh = j_head-1;
 								for (; l < bjh; ++l)
 									lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -271,7 +271,7 @@ namespace LinBox
 				std::cerr << "----------------------------------------------------------" << std::endl;
 #endif
 				if (indpermut != static_cast<long>(k)) {
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < nj; ++l)
 						if (lignecourante[(size_t)l] >= k) break;
@@ -283,7 +283,7 @@ namespace LinBox
 						++columns[(size_t)indpermut];
 						tmp = (E) indpermut;
 
-						unsigned long bjh = nj - 1;
+						size_t bjh = nj - 1;
 						for (; l < bjh; ++l)
 							lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 

--- a/linbox/algorithms/gauss/gauss-elim.inl
+++ b/linbox/algorithms/gauss/gauss-elim.inl
@@ -33,10 +33,10 @@ namespace LinBox
 	template <class _Field>
 	template <class Vector> inline void
 	GaussDomain<_Field>::permute (Vector              &lignecourante,
-				      const unsigned long &indcol,
+				      const size_t &indcol,
 				      const long &indpermut) const
 	{
-		const unsigned long k = indcol - 1;
+		const size_t k = indcol - 1;
 
 #if 0
 		std::cerr << "B PERMUTE: " << indpermut << " <--> " << k << " of  [";
@@ -121,7 +121,7 @@ namespace LinBox
 	template <class Vector, class D> inline void
 	GaussDomain<_Field>::eliminate (Vector              &lignecourante,
 					const Vector        &lignepivot,
-					const unsigned long &indcol,
+					const size_t &indcol,
 					const long &indpermut,
 					D                   &columns) const
 	{
@@ -129,8 +129,8 @@ namespace LinBox
 		typedef typename Vector::value_type E;
 		typedef typename E::first_type E1;
 
-		unsigned long k = indcol - 1;
-		unsigned long nj = lignecourante.size () ;
+		size_t k = indcol - 1;
+		size_t nj = lignecourante.size () ;
 #if 0
 		std::cerr << "BEGIN ELIMINATE, k: " << k << ", nj: " << nj << ", indpermut: " << indpermut << ", indcol: " << indcol << std::endl;
 		std::cerr << "lignepivot: [";
@@ -146,7 +146,7 @@ namespace LinBox
 		std::cerr << ']' << std::endl;
 #endif
 		if (nj > 0) {
-			unsigned long j_head = 0;
+			size_t j_head = 0;
 
 			for (; j_head < nj; ++j_head) {
 				if (static_cast<long>(lignecourante[(size_t)j_head].first) >= indpermut) break;
@@ -180,14 +180,14 @@ namespace LinBox
 					}
 					// -------------------------------------------
 					// Elimination
-					unsigned long npiv = lignepivot.size ();
+					size_t npiv = lignepivot.size ();
 					Vector construit (nj + npiv);
 
 					// construit : <-- j
 					// courante  : <-- m
 					// pivot     : <-- l
-					unsigned long j = 0;
-					unsigned long m = j_head + 1;
+					size_t j = 0;
+					size_t m = j_head + 1;
 
 					// A[i,k] <-- - A[i,k] / A[k,k]
 					Element headcoeff;
@@ -203,14 +203,14 @@ namespace LinBox
 					}
 
 
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < npiv; l++)
 						if (lignepivot[l].first > k) break;
 
 					// for all j such that (j>k) and A[k,j]!=0
 					while (l < npiv) {
-					unsigned long j_piv;
+					size_t j_piv;
 						j_piv = lignepivot[l].first;
 
 						// if A[k,j]=0, then A[i,j] <-- A[i,j]
@@ -270,7 +270,7 @@ namespace LinBox
 #endif
 					if (indpermut != static_cast<long>(k)) {
 						if (j_head>0) {
-							unsigned long l = 0;
+							size_t l = 0;
 
 							for (; l < nj; ++l)
 								if (lignecourante[(size_t)l].first >= k) break;
@@ -282,7 +282,7 @@ namespace LinBox
 								++columns[(size_t)indpermut];
 								tmp.first = (E1)indpermut;
 
-								unsigned long bjh = j_head-1;
+								size_t bjh = j_head-1;
 								for (; l < bjh; ++l)
 									lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -305,7 +305,7 @@ namespace LinBox
 				std::cerr << "----------------------------------------------------------" << std::endl;
 #endif
 				if (indpermut != static_cast<long>(k)) {
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < nj; ++l)
 						if (lignecourante[(size_t)l].first >= k) break;
@@ -317,7 +317,7 @@ namespace LinBox
 						++columns[(size_t)indpermut];
 						tmp.first = (E1)indpermut;
 
-						unsigned long bjh = nj - 1;
+						size_t bjh = nj - 1;
 						for (; l < bjh; ++l)
 							lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -352,17 +352,17 @@ namespace LinBox
 	GaussDomain<_Field>::eliminate (Element             &headpivot,
 					Vector              &lignecourante,
 					const Vector        &lignepivot,
-					const unsigned long indcol,
+					const size_t indcol,
 					const long indpermut,
-					const unsigned long npiv,
+					const size_t npiv,
 					D                   &columns) const
 	{
 
 		typedef typename Vector::value_type E;
 		typedef typename E::first_type E1;
 
-		unsigned long k = indcol - 1;
-		unsigned long nj = lignecourante.size () ;
+		size_t k = indcol - 1;
+		size_t nj = lignecourante.size () ;
 #if 0
 		std::cerr << "BEGIN ELIMINATE, k: " << k << ", nj: " << nj << ", indpermut: " << indpermut << ", indcol: " << indcol << std::endl;
 		std::cerr << "lignepivot: [";
@@ -378,7 +378,7 @@ namespace LinBox
 		std::cerr << ']' << std::endl;
 #endif
 		if (nj > 0) {
-			unsigned long j_head = 0;
+			size_t j_head = 0;
 
 			for (; j_head < nj; ++j_head) {
 				if (static_cast<long>(lignecourante[(size_t)j_head].first) >= indpermut) break;
@@ -417,8 +417,8 @@ namespace LinBox
 					// construit : <-- j
 					// courante  : <-- m
 					// pivot     : <-- l
-					unsigned long j = 0;
-					unsigned long m = j_head + 1;
+					size_t j = 0;
+					size_t m = j_head + 1;
 
 					// A[i,k] <-- - A[i,k] / A[k,k]
 					Element headcoeff;
@@ -437,14 +437,14 @@ namespace LinBox
 					}
 
 
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < npiv; l++)
 						if (lignepivot[l].first > k) break;
 
 					// for all j such that (j>k) and A[k,j]!=0
 					while (l < npiv) {
-						unsigned long j_piv;
+						size_t j_piv;
 						j_piv = lignepivot[l].first;
 
 						// if A[k,j]=0, then A[i,j] <-- A[i,j]
@@ -504,7 +504,7 @@ namespace LinBox
 #endif
 					if (indpermut != static_cast<long>(k)) {
 						if (j_head>0) {
-							unsigned long l = 0;
+							size_t l = 0;
 
 							for (; l < nj; ++l)
 								if (lignecourante[(size_t)l].first >= k) break;
@@ -516,7 +516,7 @@ namespace LinBox
 								++columns[(size_t)indpermut];
 								tmp.first = (E1)indpermut;
 
-								unsigned long bjh = j_head-1;
+								size_t bjh = j_head-1;
 								for (; l < bjh; ++l)
 									lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -539,7 +539,7 @@ namespace LinBox
 				std::cerr << "----------------------------------------------------------" << std::endl;
 #endif
 				if (indpermut != static_cast<long>(k)) {
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < nj; ++l)
 						if (lignecourante[(size_t)l].first >= k) break;
@@ -551,7 +551,7 @@ namespace LinBox
 						++columns[(size_t)indpermut];
 						tmp.first = (E1)indpermut;
 
-						unsigned long bjh = nj - 1;
+						size_t bjh = nj - 1;
 						for (; l < bjh; ++l)
 							lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -585,17 +585,17 @@ namespace LinBox
 	template <class Vector> inline void
 	GaussDomain<_Field>::eliminate (Vector              &lignecourante,
 					const Vector        &lignepivot,
-					const unsigned long &indcol,
+					const size_t &indcol,
 					const long &indpermut) const
 	{
 		typedef typename Vector::value_type E;
 		typedef typename E::first_type E1;
 
-		unsigned long k = indcol - 1;
-		unsigned long nj = lignecourante.size () ;
+		size_t k = indcol - 1;
+		size_t nj = lignecourante.size () ;
 
 		if (nj > 0) {
-			unsigned long j_head = 0;
+			size_t j_head = 0;
 
 			for (; j_head < nj; ++j_head)
 				if (static_cast<long>(lignecourante[(size_t)j_head].first) >= indpermut) break;
@@ -622,13 +622,13 @@ namespace LinBox
 					}
 					// -------------------------------------------
 					// Elimination
-					unsigned long npiv = lignepivot.size ();
+					size_t npiv = lignepivot.size ();
 					Vector construit (nj + npiv);
 					// construit : <-- j
 					// courante  : <-- m
 					// pivot     : <-- l
-					unsigned long j = 0;
-					unsigned long m = j_head + 1;
+					size_t j = 0;
+					size_t m = j_head + 1;
 
 					// A[i,k] <-- - A[i,k] / A[k,k]
 
@@ -642,14 +642,14 @@ namespace LinBox
 						j++;
 					}
 
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < npiv; l++)
 						if (lignepivot[l].first > k) break;
 
 					// for all j such that (j>k) and A[k,j]!=0
 					while (l < npiv) {
-					unsigned long j_piv;
+					size_t j_piv;
 						j_piv = lignepivot[l].first;
 
 						// if A[k,j]=0, then A[i,j] <-- A[i,j]
@@ -694,7 +694,7 @@ namespace LinBox
 					// Permutation
 					if (indpermut != static_cast<long>(k)) {
 						if (j_head > 0) {
-							unsigned long l = 0;
+							size_t l = 0;
 
 							for (; l < nj; ++l)
 								if (lignecourante[(size_t)l].first >= k) break;
@@ -704,7 +704,7 @@ namespace LinBox
 								E tmp = lignecourante[(size_t)l];
 								tmp.first = (E1) indpermut;
 
-								unsigned long bjh = j_head -1;
+								size_t bjh = j_head -1;
 								for (; l < bjh; l++)
 									lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -728,7 +728,7 @@ namespace LinBox
 				std::cerr << "----------------------------------------------------------" << std::endl;
 #endif
 				if (indpermut != static_cast<long>(k)) {
-					unsigned long l = 0;
+					size_t l = 0;
 
 					for (; l < nj; ++l)
 						if (lignecourante[(size_t)l].first >= k) break;
@@ -738,7 +738,7 @@ namespace LinBox
 						E tmp = lignecourante[(size_t)l];
 						tmp.first = (E1) indpermut;
 
-						unsigned long bjh = nj - 1;
+						size_t bjh = nj - 1;
 						for (; l < bjh; l++)
 							lignecourante[(size_t)l] = lignecourante[(size_t)l + 1];
 
@@ -759,10 +759,10 @@ namespace LinBox
 template <class _Field>
 template <class Vector>
 void GaussDomain<_Field>::permute (Vector              &lignecourante,
-				   const unsigned long &indcol,
+				   const size_t &indcol,
 				   const long &indpermut)
 {
-	const unsigned long k = indcol - 1;
+	const size_t k = indcol - 1;
 #if 0
 	std::cerr << "B PERMUTE: " << indpermut << " <--> " << k << " of  [";
 	for(typename Vector::const_iterator refs =  lignecourante.begin();
@@ -773,14 +773,14 @@ void GaussDomain<_Field>::permute (Vector              &lignecourante,
 #endif
 
 	// precondition indpermut != k
-	unsigned long nj = lignecourante.size () ;
+	size_t nj = lignecourante.size () ;
 	if (nj > 0) {
 		Element tmp; field().init(tmp);
-		unsigned long kin = 0;
+		size_t kin = 0;
 		for (; kin < nj; ++kin)
 			if (static_cast<long>(lignecourante[kin].first) >= k) break;
 		if (kin < nj) {
-			unsigned long pin = kin;
+			size_t pin = kin;
 			for (; pin < nj; ++pin)
 				if (static_cast<long>(lignecourante[(size_t)pin].first) >= indpermut) break;
 			if ( static_cast<long>(lignecourante[kin].first) == k) {

--- a/linbox/algorithms/gauss/gauss-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-gf2.inl
@@ -47,13 +47,13 @@ namespace LinBox
 {
 	// Specialization over GF2
 	template <class SparseSeqMatrix, class Perm>
-	inline unsigned long&
-	GaussDomain<GF2>::InPlaceLinearPivoting (unsigned long &Rank,
+	inline size_t&
+	GaussDomain<GF2>::InPlaceLinearPivoting (size_t &Rank,
 						 bool          &determinant,
 						 SparseSeqMatrix        &LigneA,
 						 Perm           &P,
-						 unsigned long Ni,
-						 unsigned long Nj) const
+						 size_t Ni,
+						 size_t Nj) const
 	{
 		// Requirements : LigneA is an array of sparse rows
 		// In place (LigneA is modified)
@@ -74,8 +74,8 @@ namespace LinBox
 
 
 		// assignment of LigneA with the domain object
-		for (unsigned long jj = 0; jj < Ni; ++jj)
-			for (unsigned long k = 0; k < LigneA[jj].size (); k++)
+		for (size_t jj = 0; jj < Ni; ++jj)
+			for (size_t k = 0; k < LigneA[jj].size (); k++)
 				++col_density[LigneA[jj][(size_t)k]];
 
 		long last = (long)Ni - 1;
@@ -209,15 +209,15 @@ namespace LinBox
 	}
 
 	// Specialization over GF2
-	template <class SparseSeqMatrix, class Perm> inline unsigned long&
-	GaussDomain<GF2>::QLUPin (unsigned long &Rank,
+	template <class SparseSeqMatrix, class Perm> inline size_t&
+	GaussDomain<GF2>::QLUPin (size_t &Rank,
 				  bool          &determinant,
 				  Perm          &Q,
 				  SparseSeqMatrix        &LigneL,
 				  SparseSeqMatrix        &LigneA,
 				  Perm          &P,
-				  unsigned long Ni,
-				  unsigned long Nj) const
+				  size_t Ni,
+				  size_t Nj) const
 	{
 		linbox_check( Q.coldim() == Q.rowdim() );
 		linbox_check( P.coldim() == P.rowdim() );
@@ -251,8 +251,8 @@ namespace LinBox
 		std::deque<std::pair<size_t,size_t> > invQ;
 
 		// assignment of LigneA with the domain object
-		for (unsigned long jj = 0; jj < Ni; ++jj)
-			for (unsigned long k = 0; k < LigneA[jj].size (); k++)
+		for (size_t jj = 0; jj < Ni; ++jj)
+			for (size_t k = 0; k < LigneA[jj].size (); k++)
 				++col_density[LigneA[jj][(size_t)k]];
 
 		long last = (long)Ni - 1;

--- a/linbox/algorithms/gauss/gauss-nullspace.inl
+++ b/linbox/algorithms/gauss/gauss-nullspace.inl
@@ -42,14 +42,14 @@ namespace LinBox
 	// U is supposed full Rank upper triangular
 	template <class _Field>
 	template <class _Matrix, class Perm, class Block> inline Block&
-	GaussDomain<_Field>::nullspacebasis(Block& x, unsigned long Rank, const _Matrix& U, const Perm& P)  const
+	GaussDomain<_Field>::nullspacebasis(Block& x, size_t Rank, const _Matrix& U, const Perm& P)  const
 	{
 		if (Rank == 0) {
 			for(size_t i=0; i<U.coldim(); ++i)
 				x.setEntry(i,i,field().one);
 		}
 		else {
-			unsigned long nullity = U.coldim()-Rank;
+			size_t nullity = U.coldim()-Rank;
 			if (nullity != 0) {
 				// compute U2T s.t. U = [ U1 | -U2T^T ]
 				_Matrix U2T(field(),nullity,Rank);
@@ -99,7 +99,7 @@ namespace LinBox
 	GaussDomain<_Field>::nullspacebasisin(Block& x, _Matrix& A)  const
 	{
 		typename Field::Element Det;
-		unsigned long Rank;
+		size_t Rank;
 		size_t Ni(A.rowdim()),Nj(A.coldim());
 
 		Permutation<Field> P(field(),(int)Nj);

--- a/linbox/algorithms/gauss/gauss-pivot-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-pivot-gf2.inl
@@ -32,7 +32,7 @@ namespace LinBox
 {
 	template <class Vector, class D> inline void
 	GaussDomain<GF2>::SparseFindPivotBinary (Vector        	&lignepivot,
-						 unsigned long 	&indcol,
+						 size_t 	&indcol,
 						 long 		&indpermut,
 						 D             	&columns,
 						 bool		&) const //determinant
@@ -100,7 +100,7 @@ namespace LinBox
 
 	template <class Vector> inline void
 	GaussDomain<GF2>::SparseFindPivotBinary (Vector &lignepivot,
-						 unsigned long &indcol,
+						 size_t &indcol,
 						 long &indpermut,
 						 bool& ) const // determinant
 	{

--- a/linbox/algorithms/gauss/gauss-pivot.inl
+++ b/linbox/algorithms/gauss/gauss-pivot.inl
@@ -34,7 +34,7 @@ namespace LinBox
 	template <class _Field>
 	template <class Vector, class D> inline void
 	GaussDomain<_Field>::SparseFindPivot (Vector        	&lignepivot,
-					      unsigned long 	&indcol,
+					      size_t 	&indcol,
 					      long 		&indpermut,
 					      D             	&columns,
 					      Element		&determinant) const
@@ -108,7 +108,7 @@ namespace LinBox
 	template <class _Field>
 	template <class Vector> inline void
 	GaussDomain<_Field>::SparseFindPivot (Vector &lignepivot,
-					      unsigned long &indcol,
+					      size_t &indcol,
 					      long &indpermut,
 					      Element& determinant) const
 	{
@@ -131,7 +131,7 @@ namespace LinBox
 	template <class _Field>
 	template <class Vector> inline void
 	GaussDomain<_Field>::FindPivot (Vector &lignepivot,
-					unsigned long &k,
+					size_t &k,
 					long &indpermut) const
 	{
 		// Dense lignepivot

--- a/linbox/algorithms/gauss/gauss-rank-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-rank-gf2.inl
@@ -33,11 +33,11 @@
 
 namespace LinBox
 {
-	template <class SparseSeqMatrix> unsigned long&
-	GaussDomain<GF2>::rankin(unsigned long &Rank,
+	template <class SparseSeqMatrix> size_t&
+	GaussDomain<GF2>::rankin(size_t &Rank,
 				 SparseSeqMatrix        &A,
-				 unsigned long  Ni,
-				 unsigned long  Nj,
+				 size_t  Ni,
+				 size_t  Nj,
 				 SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		Element determinant;
@@ -51,8 +51,8 @@ namespace LinBox
 	}
 
 
-	template <class SparseSeqMatrix> unsigned long&
-	GaussDomain<GF2>::rankin(unsigned long &Rank,
+	template <class SparseSeqMatrix> size_t&
+	GaussDomain<GF2>::rankin(size_t &Rank,
 				 SparseSeqMatrix        &A,
 				 SparseEliminationTraits::PivotStrategy   reord)  const
 	{
@@ -61,23 +61,23 @@ namespace LinBox
 
 
 
-	template <class SparseSeqMatrix> unsigned long&
-	GaussDomain<GF2>::rank(unsigned long &rk,
+	template <class SparseSeqMatrix> size_t&
+	GaussDomain<GF2>::rank(size_t &rk,
 			       const SparseSeqMatrix        &A,
 			       SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		return rank(rk, A,  A.rowdim (), A.coldim (), reord);
 	}
 
-	template <class SparseSeqMatrix> unsigned long&
-	GaussDomain<GF2>::rank(unsigned long &Rank,
+	template <class SparseSeqMatrix> size_t&
+	GaussDomain<GF2>::rank(size_t &Rank,
 			       const SparseSeqMatrix        &A,
-			       unsigned long  Ni,
-			       unsigned long  Nj,
+			       size_t  Ni,
+			       size_t  Nj,
 			       SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		SparseSeqMatrix CopyA(Ni);
-		for(unsigned long i = 0; i < Ni; ++i)
+		for(size_t i = 0; i < Ni; ++i)
 			CopyA[i] = A[i];
 		return rankin(Rank, CopyA, Ni, Nj, reord);
 	}

--- a/linbox/algorithms/gauss/gauss-rank.inl
+++ b/linbox/algorithms/gauss/gauss-rank.inl
@@ -31,11 +31,11 @@
 namespace LinBox
 {
 	template <class _Field>
-	template <class _Matrix> unsigned long&
-	GaussDomain<_Field>::rankin(unsigned long &Rank,
+	template <class _Matrix> size_t&
+	GaussDomain<_Field>::rankin(size_t &Rank,
 				    _Matrix        &A,
-				    unsigned long  Ni,
-				    unsigned long  Nj,
+				    size_t  Ni,
+				    size_t  Nj,
 				    SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		Element determinant;
@@ -47,8 +47,8 @@ namespace LinBox
 
 
 	template <class _Field>
-	template <class _Matrix> unsigned long&
-	GaussDomain<_Field>::rankin(unsigned long &Rank,
+	template <class _Matrix> size_t&
+	GaussDomain<_Field>::rankin(size_t &Rank,
 				    _Matrix        &A,
 				    SparseEliminationTraits::PivotStrategy   reord)  const
 	{
@@ -58,8 +58,8 @@ namespace LinBox
 
 
 	template <class _Field>
-	template <class _Matrix> unsigned long&
-	GaussDomain<_Field>::rank(unsigned long &rk,
+	template <class _Matrix> size_t&
+	GaussDomain<_Field>::rank(size_t &rk,
 				  const _Matrix        &A,
 				  SparseEliminationTraits::PivotStrategy   reord)  const
 	{
@@ -67,15 +67,15 @@ namespace LinBox
 	}
 
 	template <class _Field>
-	template <class _Matrix> unsigned long&
-	GaussDomain<_Field>::rank(unsigned long &Rank,
+	template <class _Matrix> size_t&
+	GaussDomain<_Field>::rank(size_t &Rank,
 				  const _Matrix        &A,
-				  unsigned long  Ni,
-				  unsigned long  Nj,
+				  size_t  Ni,
+				  size_t  Nj,
 				  SparseEliminationTraits::PivotStrategy   reord)  const
 	{
 		_Matrix CopyA(Ni);
-		for(unsigned long i = 0; i < Ni; ++i)
+		for(size_t i = 0; i < Ni; ++i)
 			CopyA[i] = A[i];
 		return rankin(Rank, CopyA, Ni, Nj, reord);
 	}

--- a/linbox/algorithms/gauss/gauss-solve-gf2.inl
+++ b/linbox/algorithms/gauss/gauss-solve-gf2.inl
@@ -37,7 +37,7 @@ namespace LinBox
 
 
 	template <class SparseSeqMatrix, class Perm, class Vector1, class Vector2>
-	Vector1& GaussDomain<GF2>::solve(Vector1& x, Vector1& w, unsigned long Rank,
+	Vector1& GaussDomain<GF2>::solve(Vector1& x, Vector1& w, size_t Rank,
 					 const Perm& Q, const SparseSeqMatrix& L,
 					 const SparseSeqMatrix& U, const Perm& P,
 					 const Vector2& b) const
@@ -62,7 +62,7 @@ namespace LinBox
 	{
 
 		typename GF2::Element Det;
-		unsigned long Rank;
+		size_t Rank;
 		const GF2 F2;
 		SparseSeqMatrix L(F2, A.rowdim(), A.rowdim());
 		Permutation<GF2> Q(F2,(int)A.rowdim());
@@ -86,7 +86,7 @@ namespace LinBox
 	{
 
 		typename GF2::Element Det;
-		unsigned long Rank;
+		size_t Rank;
 		const GF2 F2;
 		SparseSeqMatrix L(F2, A.rowdim(), A.rowdim());
 		Permutation<GF2> Q((int)A.rowdim(),F2);

--- a/linbox/algorithms/gauss/gauss-solve.inl
+++ b/linbox/algorithms/gauss/gauss-solve.inl
@@ -38,7 +38,7 @@ namespace LinBox
 
 	template <class _Field>
 	template <class _Matrix, class Perm, class Vector1, class Vector2> inline Vector1&
-	GaussDomain<_Field>::solve(Vector1& x, Vector1& w, unsigned long Rank, const Perm& Q, const _Matrix& L, const _Matrix& U, const Perm& P, const Vector2& b)  const
+	GaussDomain<_Field>::solve(Vector1& x, Vector1& w, size_t Rank, const Perm& Q, const _Matrix& L, const _Matrix& U, const Perm& P, const Vector2& b)  const
 	{
             // Q L U P x = b
 		Vector2 y(U.field(),U.rowdim()), v(U.field(),U.rowdim());
@@ -62,7 +62,7 @@ namespace LinBox
 	{
 
 		typename Field::Element Det;
-		unsigned long Rank;
+		size_t Rank;
 		_Matrix L(field(), A.rowdim(), A.rowdim());
 		Permutation<Field> Q(field(),(int)A.rowdim());
 		Permutation<Field> P(field(),(int)A.coldim());
@@ -99,7 +99,7 @@ namespace LinBox
 	GaussDomain<_Field>::solvein(Vector1& x, _Matrix& A, const Vector2& b, Random& generator)  const
 	{
 		typename Field::Element Det;
-		unsigned long Rank;
+		size_t Rank;
 		_Matrix L(field(), A.rowdim(), A.rowdim());
 		Permutation<Field> Q(field(),(int)A.rowdim());
 		Permutation<Field> P(field(),(int)A.coldim());

--- a/linbox/algorithms/gauss/gauss.inl
+++ b/linbox/algorithms/gauss/gauss.inl
@@ -57,15 +57,15 @@
 namespace LinBox
 {
     template <class _Field>
-    template <class _Matrix, class Perm> inline unsigned long&
-    GaussDomain<_Field>::QLUPin (unsigned long &Rank,
+    template <class _Matrix, class Perm> inline size_t&
+    GaussDomain<_Field>::QLUPin (size_t &Rank,
                      Element       &determinant,
                      Perm          &Q,
                      _Matrix        &LigneL,
                      _Matrix        &LigneA,
                      Perm          &P,
-                     unsigned long Ni,
-                     unsigned long Nj) const
+                     size_t Ni,
+                     size_t Nj) const
     {
         linbox_check( Q.coldim() == Q.rowdim() );
         linbox_check( P.coldim() == P.rowdim() );
@@ -102,8 +102,8 @@ namespace LinBox
         std::deque<std::pair<size_t,size_t> > invQ;
 
         // assignment of LigneA with the domain object
-        for (unsigned long jj = 0; jj < Ni; ++jj)
-            for (unsigned long k = 0; k < LigneA[(size_t)jj].size (); k++)
+        for (size_t jj = 0; jj < Ni; ++jj)
+            for (size_t k = 0; k < LigneA[(size_t)jj].size (); k++)
                 ++col_density[LigneA[(size_t)jj][k].first];
 
         const long last = (long)Ni - 1;
@@ -283,15 +283,15 @@ namespace LinBox
 
 
     template <class _Field>
-    template <class _Matrix, class Perm> inline unsigned long&
-    GaussDomain<_Field>::SparseContinuation (unsigned long &Rank,
+    template <class _Matrix, class Perm> inline size_t&
+    GaussDomain<_Field>::SparseContinuation (size_t &Rank,
                      Element       &determinant,
                      std::deque<std::pair<size_t,size_t> > &invQ,
                      _Matrix        &LigneL,
                      _Matrix        &LigneA,
                      Perm          &P,
-                     unsigned long Ni,
-                     unsigned long Nj) const
+                     size_t Ni,
+                     size_t Nj) const
     {
         typedef typename _Matrix::Row        Vector;
         typedef typename Vector::value_type E;
@@ -316,16 +316,16 @@ namespace LinBox
     template <class _Field>
     template<class _Matrix, class Perm> 
     struct GaussDomain<_Field>::Continuation<_Matrix,Perm,false> {
-        unsigned long& operator()(
+        size_t& operator()(
             const GaussDomain<_Field>& GD,
-            unsigned long &Rank, 
+            size_t &Rank, 
             typename GaussDomain<_Field>::Element       &determinant,
             std::deque<std::pair<size_t,size_t> > &invQ,
             _Matrix        &LigneL,
             _Matrix        &LigneA,
             Perm          &P,
-            unsigned long Ni,
-            unsigned long Nj,
+            size_t Ni,
+            size_t Nj,
             bool degeneratedense) const 
             {
                 return GD.SparseContinuation(Rank,determinant,invQ,LigneL,LigneA,P,Ni,Nj);
@@ -335,16 +335,16 @@ namespace LinBox
     template <class _Field>
     template <class _Matrix, class Perm> 
     struct GaussDomain<_Field>::Continuation<_Matrix,Perm,true> {
-        unsigned long& operator()(
+        size_t& operator()(
             const GaussDomain<_Field>& GD,
-            unsigned long &Rank,
+            size_t &Rank,
             typename GaussDomain<_Field>::Element       &determinant,
             std::deque<std::pair<size_t,size_t> > &invQ,
             _Matrix        &LigneL,
             _Matrix        &LigneA,
             Perm          &P,
-            unsigned long Ni,
-            unsigned long Nj,
+            size_t Ni,
+            size_t Nj,
             bool degeneratedense) const
             {
                 if (degeneratedense) {
@@ -361,15 +361,15 @@ namespace LinBox
 
 
     template <class _Field>
-    template <class _Matrix, class Perm> inline unsigned long&
-    GaussDomain<_Field>::DenseQLUPin (unsigned long &Rank,
+    template <class _Matrix, class Perm> inline size_t&
+    GaussDomain<_Field>::DenseQLUPin (size_t &Rank,
                      Element       &determinant,
                      std::deque<std::pair<size_t,size_t> > &dinvQ,
                      _Matrix        &dLigneL,
                      _Matrix        &dLigneA,
                      Perm          &dP,
-                     unsigned long Ni,
-                     unsigned long Nj) const
+                     size_t Ni,
+                     size_t Nj) const
     {
         linbox_check( dP.coldim()      == dP.rowdim() );
         linbox_check( dLigneL.coldim() == dLigneL.rowdim() );
@@ -486,12 +486,12 @@ namespace LinBox
     
 
     template <class _Field>
-    template <class _Matrix> inline unsigned long&
-    GaussDomain<_Field>::InPlaceLinearPivoting (unsigned long &Rank,
+    template <class _Matrix> inline size_t&
+    GaussDomain<_Field>::InPlaceLinearPivoting (size_t &Rank,
                             Element        &determinant,
                             _Matrix         &LigneA,
-                            unsigned long   Ni,
-                            unsigned long   Nj) const
+                            size_t   Ni,
+                            size_t   Nj) const
     {
         typedef typename _Matrix::Row        Vector;
 
@@ -515,8 +515,8 @@ namespace LinBox
         std::vector<size_t> col_density (Nj);
 
         // assignment of LigneA with the domain object
-        for (unsigned long jj = 0; jj < Ni; ++jj)
-            for (unsigned long k = 0; k < LigneA[(size_t)jj].size (); k++)
+        for (size_t jj = 0; jj < Ni; ++jj)
+            for (size_t k = 0; k < LigneA[(size_t)jj].size (); k++)
                 ++col_density[LigneA[(size_t)jj][k].first];
 
         const long last = (long)Ni - 1;
@@ -535,7 +535,7 @@ namespace LinBox
 
 #ifdef __LINBOX_FILLIN__
             if ( ! (k % 100) ) {
-                unsigned long l;
+                size_t l;
                 long sl;
                 commentator().progress (k);
                 for (sl = 0, l = 0; l < Ni; ++l)
@@ -555,9 +555,9 @@ namespace LinBox
 #endif
 
             if (s) {
-                unsigned long l;
+                size_t l;
                 // Row permutation for the sparsest row
-                for (l = (unsigned long)k + 1; l < (unsigned long)Ni; ++l) {
+                for (l = (size_t)k + 1; l < (size_t)Ni; ++l) {
                 long sl;
                     if (((sl = (long)LigneA[(size_t)l].size ()) < s) && (sl)) {
                         s = sl;
@@ -577,7 +577,7 @@ namespace LinBox
                 SparseFindPivot (LigneA[(size_t)k], Rank, c, col_density, determinant);
                 //                     LigneA.write(std::cerr << "PIV, k:" << k << ", Rank:" << Rank << ", c:" << c)<<std::endl;
                 if (c != -1) {
-                    for (l = (unsigned long)k + 1; l < (unsigned long)Ni; ++l)
+                    for (l = (size_t)k + 1; l < (size_t)Ni; ++l)
                         eliminate (LigneA[(size_t)l], LigneA[(size_t)k], Rank, c, col_density);
                 }
 
@@ -627,13 +627,13 @@ namespace LinBox
 
 
     template <class _Field>
-    template <class _Matrix, class Perm> inline unsigned long&
-    GaussDomain<_Field>::InPlaceLinearPivoting (unsigned long &Rank,
+    template <class _Matrix, class Perm> inline size_t&
+    GaussDomain<_Field>::InPlaceLinearPivoting (size_t &Rank,
                             Element        &determinant,
                             _Matrix         &LigneA,
                             Perm           &P,
-                            unsigned long   Ni,
-                            unsigned long   Nj) const
+                            size_t   Ni,
+                            size_t   Nj) const
     {
         typedef typename _Matrix::Row        Vector;
 
@@ -655,8 +655,8 @@ namespace LinBox
         std::vector<size_t> col_density (Nj);
 
         // assignment of LigneA with the domain object
-        for (unsigned long jj = 0; jj < Ni; ++jj)
-            for (unsigned long k = 0; k < LigneA[(size_t)jj].size (); k++)
+        for (size_t jj = 0; jj < Ni; ++jj)
+            for (size_t k = 0; k < LigneA[(size_t)jj].size (); k++)
                 ++col_density[LigneA[(size_t)jj][k].first];
 
         const long last = (long)Ni - 1;
@@ -676,7 +676,7 @@ namespace LinBox
 #ifdef __LINBOX_FILLIN__
             if ( ! (k % 100) )
             {
-                unsigned long l;
+                size_t l;
                 long sl;
                 commentator().progress (k);
                 for (sl = 0, l = 0; l < Ni; ++l)
@@ -699,9 +699,9 @@ namespace LinBox
 
 
             if (s) {
-                unsigned long l;
+                size_t l;
                 // Row permutation for the sparsest row
-                for (l = (unsigned long)k + 1; l < (unsigned long)Ni; ++l) {
+                for (l = (size_t)k + 1; l < (size_t)Ni; ++l) {
                 long sl;
                     if (((sl =(long) LigneA[(size_t)l].size ()) < s) && (sl)) {
                         s = sl;
@@ -726,7 +726,7 @@ namespace LinBox
                     for (long ll=0; ll < k ; ++ll)
                         permute( LigneA[(size_t)ll], Rank, c);
 
-                    for (l = (unsigned long)k + 1; l < (unsigned long)Ni; ++l)
+                    for (l = (size_t)k + 1; l < (size_t)Ni; ++l)
                         eliminate (LigneA[(size_t)l], LigneA[(size_t)k], Rank, c, col_density);
                 }
 
@@ -779,12 +779,12 @@ namespace LinBox
     }
 
     template <class _Field>
-    template <class _Matrix> inline unsigned long&
-    GaussDomain<_Field>::NoReordering (unsigned long &res,
+    template <class _Matrix> inline size_t&
+    GaussDomain<_Field>::NoReordering (size_t &res,
                        Element       &determinant,
                        _Matrix        &LigneA,
-                       unsigned long  Ni,
-                       unsigned long  Nj) const
+                       size_t  Ni,
+                       size_t  Nj) const
     {
         // Requirements : SLA is an array of sparse rows
         // IN PLACE.
@@ -808,7 +808,7 @@ namespace LinBox
         field().assign(determinant,field().one);
         const long last = (long)Ni - 1;
         long c;
-        unsigned long indcol (0);
+        size_t indcol (0);
 
         for (long k = 0; k < last; ++k) {
             if (!(k % 1000))
@@ -818,8 +818,8 @@ namespace LinBox
             if (!LigneA[(size_t)k].empty ()) {
                 SparseFindPivot (LigneA[(size_t)k], indcol, c, determinant);
                 if (c !=  -1) {
-                    unsigned long l;
-                    for (l = (unsigned long)k + 1; l < (unsigned long)Ni; ++l)
+                    size_t l;
+                    for (l = (size_t)k + 1; l < (size_t)Ni; ++l)
                         eliminate (LigneA[(size_t)l], LigneA[(size_t)k], indcol, c);
                 }
 
@@ -862,7 +862,7 @@ namespace LinBox
     template<class Vector> inline void
     GaussDomain<_Field>::Upper (Vector        &lignecur,
                     const Vector  &lignepivot,
-                    unsigned long  indcol,
+                    size_t  indcol,
                     long  indpermut) const
     {
 
@@ -891,7 +891,7 @@ namespace LinBox
     template <class Vector> inline void
     GaussDomain<_Field>::LU (Vector        &lignecur,
                  const Vector  &lignepivot,
-                 unsigned long  indcol,
+                 size_t  indcol,
                  long  indpermut) const
     {
         long n = lignecur.size ();
@@ -915,8 +915,8 @@ namespace LinBox
 
 
     template <class _Field>
-    template <class _Matrix> inline unsigned long &
-    GaussDomain<_Field>::upperin (unsigned long &res, _Matrix &A) const
+    template <class _Matrix> inline size_t &
+    GaussDomain<_Field>::upperin (size_t &res, _Matrix &A) const
     {
         // Requirements : A is an array of rows
         // In place (A is modified)
@@ -924,7 +924,7 @@ namespace LinBox
         long Ni = A.rowdim ();
         const long last = Ni - 1;
         long c;
-        unsigned long indcol = 0;
+        size_t indcol = 0;
 
         for (long k = 0; k < last; ++k) {
             FindPivot (A[k], indcol, c);
@@ -938,8 +938,8 @@ namespace LinBox
     }
 
     template <class _Field>
-    template <class _Matrix> inline unsigned long &
-    GaussDomain<_Field>::LUin (unsigned long &res, _Matrix &A) const
+    template <class _Matrix> inline size_t &
+    GaussDomain<_Field>::LUin (size_t &res, _Matrix &A) const
     {
         // Requirements : A is an array of rows
         // In place (A is modified)
@@ -948,7 +948,7 @@ namespace LinBox
         long Ni = A.rowdim ();
         const long last = Ni - 1;
         long c;
-        unsigned long indcol = 0;
+        size_t indcol = 0;
 
         for (long k = 0; k < last; ++k) {
             FindPivot (A[k], indcol, c);

--- a/linbox/algorithms/lifting-container.h
+++ b/linbox/algorithms/lifting-container.h
@@ -857,8 +857,8 @@ namespace LinBox
 				size_t minpoly_degree;
 				minpoly_degree=_MinPoly.size();
 				FPolynomial Poly;
-				unsigned long deg;
-				unsigned long size= (_Ap.rowdim() - _MinPoly.size())<<1 ;
+				size_t deg;
+				size_t size= (_Ap.rowdim() - _MinPoly.size())<<1 ;
 				BlackboxContainer<Field, FMatrix > Sequence(&_Ap,field(),error,size);
 				MasseyDomain<Field,BlackboxContainer<Field, FMatrix > > MD(&Sequence);
 				MD.minpoly(Poly,deg);
@@ -1469,7 +1469,7 @@ namespace LinBox
 		const FMatrix&                       UU;
 		const Permutation<_Field>&           QQ;
 		const Permutation<_Field>&           PP;
-		unsigned long                     _rank;
+		size_t                     _rank;
 		const Field                     *_field;
 		mutable FVector                  _res_p;
 		mutable FVector                _digit_p;
@@ -1487,7 +1487,7 @@ namespace LinBox
 					  const Permutation<_Field>& Q,
 					  const FMatrix&     U,
 					  const Permutation<_Field>& P,
-					  unsigned long   rank,
+					  size_t   rank,
 					  const VectorIn&    b,
 					  const Prime_Type&  p) :
 			LiftingContainerBase<Ring,IMatrix> (R,A,b,p), LL(L),UU(U),QQ(Q), PP(P), _rank(rank),

--- a/linbox/algorithms/massey-domain.h
+++ b/linbox/algorithms/massey-domain.h
@@ -83,7 +83,7 @@ namespace LinBox
 		Sequence            *_container;
 		const Field                *_field;
 		VectorDomain<Field>  _VD;
-		unsigned long         EARLY_TERM_THRESHOLD;
+		size_t         EARLY_TERM_THRESHOLD;
 
 #ifdef INCLUDE_TIMING
 		// Timings
@@ -95,28 +95,28 @@ namespace LinBox
 		typedef typename Field::Element Element;
 
 		//-- Constructors
-		MasseyDomain (unsigned long ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
+		MasseyDomain (size_t ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
 			_container           (),
 			_field                   (),
 			_VD                  (),
 			EARLY_TERM_THRESHOLD (ett_default)
 		{}
 
-		MasseyDomain (const MasseyDomain<Field, Sequence> &Mat, unsigned long ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
+		MasseyDomain (const MasseyDomain<Field, Sequence> &Mat, size_t ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
 			_container           (Mat._container),
 			_field                   (Mat._field),
 			_VD                  (Mat.field()),
 			EARLY_TERM_THRESHOLD (ett_default)
 		{}
 
-		MasseyDomain (Sequence *D, unsigned long ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
+		MasseyDomain (Sequence *D, size_t ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
 			_container           (D),
 			_field                   (&(D->field ())),
 			_VD                  (D->field ()),
 			EARLY_TERM_THRESHOLD (ett_default)
 		{}
 
-		MasseyDomain (Sequence *MD, const Field &F, unsigned long ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
+		MasseyDomain (Sequence *MD, const Field &F, size_t ett_default = DEFAULT_EARLY_TERM_THRESHOLD) :
 			_container           (MD),
 			_field                   (&F),
 			_VD                  (F),
@@ -356,14 +356,14 @@ namespace LinBox
 		// ---------------------------------------------
 		// Massey
 		//
-		void pseudo_rank (unsigned long &rank)
+		void pseudo_rank (size_t &rank)
 		{
 			BlasVector<Field> phi(field());
 			massey (phi, 0);
 			rank = v_degree (phi) - v_val (phi);
 		}
 
-		void valence (Element &Valence, unsigned long &rank)
+		void valence (Element &Valence, size_t &rank)
 		{
 			commentator().start ("Valence", "LinBox::MasseyDomain::valence");
 
@@ -376,11 +376,11 @@ namespace LinBox
 		}
 
 		template<class Polynomial>
-		unsigned long pseudo_minpoly (Polynomial &phi, unsigned long &rank, bool full_poly = true)
+		size_t pseudo_minpoly (Polynomial &phi, size_t &rank, bool full_poly = true)
 		{
-			unsigned long L = (unsigned long)massey (phi, full_poly);
+			size_t L = (size_t)massey (phi, full_poly);
 			long dp = v_degree(phi);
-			rank = (unsigned long) (dp - v_val (phi));
+			rank = (size_t) (dp - v_val (phi));
 			if (phi.size()) {
 				for(long i = dp >> 1;i > 0; --i) {
 					phi[0] = phi[(size_t)i];
@@ -394,10 +394,10 @@ namespace LinBox
 		}
 
 		template<class Polynomial>
-		void minpoly (Polynomial &phi, unsigned long &rank, bool full_poly = true)
+		void minpoly (Polynomial &phi, size_t &rank, bool full_poly = true)
 		{
 			long dp = massey (phi, full_poly);
-			rank = (unsigned long) (v_degree(phi) - v_val (phi));
+			rank = (size_t) (v_degree(phi) - v_val (phi));
 			if (phi.size () > 0) {
 				phi.resize ((size_t)dp+1);
 				for (long i = dp >> 1; i > 0; --i)

--- a/linbox/algorithms/matrix-rank.h
+++ b/linbox/algorithms/matrix-rank.h
@@ -79,7 +79,7 @@ namespace LinBox
 
 			rp.setBits(FieldTraits<Field>::bestBitSize(A.coldim()));
 
-			Field F ((unsigned long)*rp);
+			Field F ((size_t)*rp);
 
 			BlasMatrix<Field> Ap(F, A.rowdim(), A.coldim());
 
@@ -232,7 +232,7 @@ namespace LinBox
 		long rankIn(SparseMatrix<Field, Row>& A) const
 		{
 
-			unsigned long result;
+			size_t result;
 
 			LinBox::rank(result, A, A.field());
 

--- a/linbox/algorithms/opencl-environ.h
+++ b/linbox/algorithms/opencl-environ.h
@@ -66,9 +66,9 @@ namespace LinBox{
 		cl_int errcode;
 
 		//Memory stats
-		unsigned long memCapacity;
-		unsigned long maxBufferSize;
-		unsigned long memInUse;
+		size_t memCapacity;
+		size_t maxBufferSize;
+		size_t memInUse;
 
 		//Device type flags
 		bool CPU;
@@ -266,7 +266,7 @@ namespace LinBox{
 		/**
 		 * getMemCapacity() accessor for the memory capacity associated with environ
 		 */
-		unsigned long getMemCapacity() const{
+		size_t getMemCapacity() const{
 			return memCapacity;
 		}
 
@@ -274,35 +274,35 @@ namespace LinBox{
 		 * getMaxBufferSize() accessor for the maximum buffer size associated
 		 * with environ
 		 */
-		unsigned long getMaxBufferSize() const{
+		size_t getMaxBufferSize() const{
 			return maxBufferSize;
 		}
 
 		/**
 		 * getMemInUse() accessor for the memory currently in use by the environ
 		 */
-		unsigned long getMemInUse() const{
+		size_t getMemInUse() const{
 			return memInUse;
 		}
 
 		/**
 		 * getMemAvailable() accessor for the memory available in the environ
 		 */
-		unsigned long getMemAvailable() const{
+		size_t getMemAvailable() const{
 			return memCapacity - memInUse;
 		}
 
 		/**
 		 * memAllocated() setter for updating the memory levels
 		 */
-		void memAllocated(unsigned long alloc){
+		void memAllocated(size_t alloc){
 			memInUse += alloc;
 		}
 
 		/**
 		 * memDeallocated() setter for updating the memory levels
 		 */
-		void memDeallocated(unsigned long dealloc){
+		void memDeallocated(size_t dealloc){
 			memInUse -= dealloc;
 		}
 
@@ -342,7 +342,7 @@ namespace LinBox{
 			pthread_mutex_lock(deviceLock);
 #else
 			deviceLock->lock();
-			memInUse = deviceLock->updateLocalValue<unsigned long>("memInUse");
+			memInUse = deviceLock->updateLocalValue<size_t>("memInUse");
 #endif
 		}
 
@@ -353,7 +353,7 @@ namespace LinBox{
 #ifndef __MPI_SHARED
 			pthread_mutex_unlock(deviceLock);
 #else
-			deviceLock->updateGlobalValue<unsigned long>("memInUse", memInUse);
+			deviceLock->updateGlobalValue<size_t>("memInUse", memInUse);
 			deviceLock->unlock();
 #endif
 		}

--- a/linbox/algorithms/polynomial-matrix/polynomial-fft-transform.h
+++ b/linbox/algorithms/polynomial-matrix/polynomial-fft-transform.h
@@ -108,7 +108,7 @@ namespace LinBox {
 			for (;;) {
 				_gen = rand() % _pl; if (_gen <= 0) continue;
 				z = 1;
-				for (unsigned long i=0; i < _m; ++i) z = z*_gen % _pl;
+				for (size_t i=0; i < _m; ++i) z = z*_gen % _pl;
 				if (z == 1) continue;
 				// _gen^i =/ 1 pour 0 <= i < m
 				_gen = z;

--- a/linbox/algorithms/rational-cra-early-multip.h
+++ b/linbox/algorithms/rational-cra-early-multip.h
@@ -40,7 +40,7 @@ namespace LinBox
 	protected:
 		// Random coefficients for a linear combination
 		// of the elements to be reconstructed
-		std::vector< unsigned long >      	randv;
+		std::vector< size_t >      	randv;
 
 		void initialize (const Integer& D, const Integer& e) {return;}; // DON'T TOUCH
 		void progress (const Integer & D, const Integer & e) {return;};
@@ -56,7 +56,7 @@ namespace LinBox
 	public:
 
 
-		EarlyMultipRatCRA(const unsigned long EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
+		EarlyMultipRatCRA(const size_t EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
 			EarlySingleRatCRA<Domain>(EARLY), FullMultipRatCRA<Domain>()
 		{ }
 
@@ -68,9 +68,9 @@ namespace LinBox
 			// of the elements to be reconstructed
 			srand48(BaseTimer::seed());
 			randv. resize ( e.size() );
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();
+			for ( std::vector<size_t>::iterator int_p = randv. begin();
 			      int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+				*int_p = ((size_t)lrand48()) % 20000;
 
 			DomainElement z;
 			// Could be much faster
@@ -87,9 +87,9 @@ namespace LinBox
 			// of the elements to be reconstructed
 			srand48(BaseTimer::seed());
 			randv. resize ( e.size() );
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();
+			for ( std::vector<size_t>::iterator int_p = randv. begin();
 			      int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+				*int_p = ((size_t)lrand48()) % 20000;
 
 			DomainElement z;
 			// Could be much faster

--- a/linbox/algorithms/rational-cra-early-single.h
+++ b/linbox/algorithms/rational-cra-early-single.h
@@ -44,7 +44,7 @@ namespace LinBox
 
 	public:
 
-		EarlySingleRatCRA(const unsigned long EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
+		EarlySingleRatCRA(const size_t EARLY=DEFAULT_EARLY_TERM_THRESHOLD) :
 			Father_t(EARLY)
 		{}
 

--- a/linbox/algorithms/rational-solver.inl
+++ b/linbox/algorithms/rational-solver.inl
@@ -148,8 +148,8 @@ namespace LinBox
 
 		SparseMatrix<Field> *Ap;
 		FPolynomial MinPoly;
-		unsigned long  deg;
-		unsigned long issingular = SINGULARITY_THRESHOLD;
+		size_t  deg;
+		size_t issingular = SINGULARITY_THRESHOLD;
 		static Field *F=NULL;
 		Prime prime = _prime;
 		do {
@@ -237,8 +237,8 @@ namespace LinBox
 
 
 		FPolynomial MinPoly;
-		unsigned long  deg;
-		unsigned long badprecondition = BAD_PRECONTITIONER_THRESHOLD;
+		size_t  deg;
+		size_t badprecondition = BAD_PRECONTITIONER_THRESHOLD;
 		Field *F;
 		Prime prime = _prime;
 		typename Field::Element tmp;
@@ -1484,7 +1484,7 @@ namespace LinBox
 		// compute LQUP Factorization
 		Permutation<Field> P(F,(int)A.coldim()),Q(F,(int)A.rowdim());
 		FMatrix L(F, A.rowdim(), A.rowdim());
-		unsigned long rank;
+		size_t rank;
 		Element_t det;
 
 		GaussDomain<Field> GD(F);

--- a/linbox/algorithms/rns.h
+++ b/linbox/algorithms/rns.h
@@ -49,16 +49,16 @@ namespace LinBox
 	template<bool Unsigned>
 	class RNS {
 	private:
-		typedef std::vector<unsigned long>  Fvect ;
+		typedef std::vector<size_t>  Fvect ;
 		typedef std::vector<integer>        Ivect ;
 		typedef Givaro::Modular<double>             Field ;
 
 		Fvect               _primes_; //!< vector of integers, pairwise coprime (or pairwise different primes)
-		unsigned long         _size_; //!< number of primes
-		unsigned long          _bit_; //!< max number of bit reachable. @todo why not max int reachable to save maybe a couple primes ? bof.
+		size_t         _size_; //!< number of primes
+		size_t          _bit_; //!< max number of bit reachable. @todo why not max int reachable to save maybe a couple primes ? bof.
 		integer             _maxint_; //!< max reachable integer.
 		integer             _midint_; //!< in signed case, the mid one.
-		unsigned long           _ps_; //!< prime size (minimum)
+		size_t           _ps_; //!< prime size (minimum)
 
 
 		typedef Givaro::RNSsystem<Integer, Field >      CRTSystem;
@@ -78,18 +78,18 @@ namespace LinBox
 		 * @param l  max recoverable bits
 		 * @param ps bitsize of the primes (defaulting to 21 because...)
 		 */
-		RNS(unsigned long l, unsigned long ps=21) ;
+		RNS(size_t l, size_t ps=21) ;
 		/*x Create a RNS with given primes.
 		 * @param primes given basis of primes
 		 * @param l      recoverable bits. If not given or 0, then it is computed. Giving it will reduce initialization time.
 		 * @warning both \c l and \c primes 'integrity' are not checked. Use \c checkRNS() member to perform the check.
 		 *
 		 */
-		// RNS(Ivect & primes, unsigned long l = 0) ;
+		// RNS(Ivect & primes, size_t l = 0) ;
 
 		// void addPrime( double prime);
 
-		// void addPrime( unsigned long newl);
+		// void addPrime( size_t newl);
 
 		// bool checkRNS() ;
 
@@ -125,16 +125,16 @@ namespace LinBox
 	template<bool Unsigned>
 	class RNSfixed {
 	private:
-		typedef std::vector<unsigned long>  Fvect ;
+		typedef std::vector<size_t>  Fvect ;
 		typedef std::vector<integer>        Ivect ;
 		typedef Givaro::Modular<double>             Field ;
 
 		Fvect               _primes_; //!< vector of integers, pairwise coprime (or pairwise different primes)
-		unsigned long         _size_; //!< number of primes
-		unsigned long          _bit_; //!< max number of bit reachable. @todo why not max int reachable to save maybe a couple primes ? bof.
+		size_t         _size_; //!< number of primes
+		size_t          _bit_; //!< max number of bit reachable. @todo why not max int reachable to save maybe a couple primes ? bof.
 		integer             _maxint_; //!< max reachable integer.
 		integer             _midint_; //!< in signed case, the mid one.
-		unsigned long           _ps_; //!< prime size (minimum)
+		size_t           _ps_; //!< prime size (minimum)
 
 
 		typedef Givaro::RNSsystemFixed<Integer>       CRTSystemFixed;
@@ -154,18 +154,18 @@ namespace LinBox
 		 * @param l  max recoverable bits
 		 * @param ps bitsize of the primes (defaulting to 21 because...)
 		 */
-		RNSfixed(unsigned long l, unsigned long ps=21) ;
+		RNSfixed(size_t l, size_t ps=21) ;
 		/*x Create a RNSfixed with given primes.
 		 * @param primes given basis of primes
 		 * @param l      recoverable bits. If not given or 0, then it is computed. Giving it will reduce initialization time.
 		 * @warning both \c l and \c primes 'integrity' are not checked. Use \c checkRNSfixed() member to perform the check.
 		 *
 		 */
-		// RNSfixed(Ivect & primes, unsigned long l = 0) ;
+		// RNSfixed(Ivect & primes, size_t l = 0) ;
 
 		// void addPrime( double prime);
 
-		// void addPrime( unsigned long newl);
+		// void addPrime( size_t newl);
 
 		// bool checkRNSfixed() ;
 

--- a/linbox/algorithms/rns.inl
+++ b/linbox/algorithms/rns.inl
@@ -38,15 +38,15 @@ namespace LinBox
 {
 	/* Constructor */
 	template<bool Unsigned>
-	RNS<Unsigned>::RNS(unsigned long l, unsigned long ps) :
+	RNS<Unsigned>::RNS(size_t l, size_t ps) :
 		_bit_(l),  _ps_(ps)
 	{
-		linbox_check(ps<30); // oupa, mais moins qu'un unsigned long
+		linbox_check(ps<30); // oupa, mais moins qu'un size_t
 		unsigned int nb_primes = (unsigned int) std::ceil(double(l)/double(ps));
 		// integer maxint = Integer::pow(2,l); XXX je veux faire ça !!!!!!
 		integer maxint = pow((integer)2,(Unsigned?l:l+1));
 		_primes_.resize(nb_primes);
-		std::set<unsigned long> primeset ;
+		std::set<size_t> primeset ;
 		size_t lg      = 0 ;
 		int tries      = 0 ;
 		int penalty    = 0 ;
@@ -56,7 +56,7 @@ namespace LinBox
 				if (curint>maxint)
 					break;
 				PrimeIterator<IteratorCategories::HeuristicTag> genprimes( (unsigned int) (_ps_+penalty) );
-				unsigned long p = genprimes.randomPrime() ;
+				size_t p = genprimes.randomPrime() ;
 				++genprimes;
 				primeset.insert(p);
 				if (lg < primeset.size()) {
@@ -78,7 +78,7 @@ namespace LinBox
 			Integer::div(_midint_,_maxint_,2);
 		_size_   = lg;
 		_primes_.resize(lg);
-		std::set<unsigned long>::iterator pset = primeset.begin();
+		std::set<size_t>::iterator pset = primeset.begin();
 		Fvect::iterator pvec = _primes_.begin();
 		for ( ; pvec != _primes_.end() ; ++pset, ++pvec) { // dumping set to vect
 			*pvec = *pset ;
@@ -164,16 +164,16 @@ namespace LinBox
 {
 	/* Constructor */
 	template<bool Unsigned>
-	RNSfixed<Unsigned>::RNSfixed(unsigned long l, unsigned long ps) :
+	RNSfixed<Unsigned>::RNSfixed(size_t l, size_t ps) :
 		_bit_(l),  _ps_(ps)
 	{
-		linbox_check(ps<30); // oupa, mais moins qu'un unsigned long
+		linbox_check(ps<30); // oupa, mais moins qu'un size_t
 		unsigned int nb_primes = (unsigned int) std::ceil(double(l)/double(ps));
 		// integer maxint = Integer::pow(2,l); XXX je veux faire ça !!!!!!
 		integer maxint = pow((integer)2,(Unsigned?l:l+1));
 		// std::cout << "target max int : " << maxint << std::endl;
 		_primes_.resize(nb_primes);
-		std::set<unsigned long> primeset ;
+		std::set<size_t> primeset ;
 		size_t lg      = 0 ;
 		int tries      = 0 ;
 		int penalty    = 0 ;
@@ -183,7 +183,7 @@ namespace LinBox
 				if (curint>maxint)
 					break;
 				PrimeIterator<IteratorCategories::HeuristicTag> genprimes((unsigned int) (_ps_+penalty) );
-				unsigned long p = genprimes.randomPrime() ;
+				size_t p = genprimes.randomPrime() ;
 				++genprimes;
 				primeset.insert(p);
 				if (lg < primeset.size()) {
@@ -206,7 +206,7 @@ namespace LinBox
 			Integer::div(_midint_,_maxint_,2);
 		_size_ = lg;
 		_primes_.resize(lg);
-		std::set<unsigned long>::iterator pset = primeset.begin();
+		std::set<size_t>::iterator pset = primeset.begin();
 		Fvect::iterator pvec = _primes_.begin();
 		for ( ; pvec != _primes_.end() ; ++pset, ++pvec) { // dumping set to vect
 			*pvec = *pset ;

--- a/linbox/algorithms/sigma-basis.h
+++ b/linbox/algorithms/sigma-basis.h
@@ -771,7 +771,7 @@ namespace LinBox
 				throw PreconditionFailed (__func__, __LINE__, "Bad random Blocks, abort\n");
 			}
 
-			unsigned long early_stop=0;
+			size_t early_stop=0;
 			long NN;
 
 			for (NN = 0; (NN < (long)length) && (early_stop < 20) ; ++NN) {
@@ -994,7 +994,7 @@ namespace LinBox
 				throw PreconditionFailed (__func__, __LINE__, "Bad random Blocks, abort\n");
 			}
 
-			unsigned long early_stop=0;
+			size_t early_stop=0;
 			long NN;
 
 			for (NN = 0; (NN < (long)length) && (early_stop < 20) ; ++NN) {

--- a/linbox/algorithms/smith-form-adaptive.inl
+++ b/linbox/algorithms/smith-form-adaptive.inl
@@ -67,7 +67,7 @@ namespace LinBox
 		std::ostream& report = commentator().report (Commentator::LEVEL_IMPORTANT, PROGRESS_REPORT);
 
 		int order = (int)(A. rowdim() < A. coldim() ? A. rowdim() : A. coldim());
-		linbox_check ((s. size() >= (unsigned long)order) && (p > 0) && ( e >= 0));
+		linbox_check ((s. size() >= (size_t)order) && (p > 0) && ( e >= 0));
 		if (e == 0) return;
 
 		if (p == 2) {
@@ -160,7 +160,7 @@ namespace LinBox
 		//std::ostream& report(std::cout);
 		std::ostream& report = commentator().report (Commentator::LEVEL_IMPORTANT, PROGRESS_REPORT);
 		int order = (int)(A. rowdim() < A. coldim() ? A. rowdim() : A. coldim());
-		linbox_check ((s. size() >= (unsigned long) order) && (p > 0) && ( e >= 0));
+		linbox_check ((s. size() >= (size_t) order) && (p > 0) && ( e >= 0));
 		integer T; T = order; T <<= 20; T = pow (T, (int) sqrt((double)order));
 		NTL::ZZ m;  NTL::conv(m, 1); int i = 0; for (i = 0; i < e; ++ i) m *= p;
 		//if (m < T)
@@ -224,7 +224,7 @@ namespace LinBox
 		std::ostream& report = commentator().report (Commentator::LEVEL_IMPORTANT, PROGRESS_REPORT);
 		report << "Computation the k-smooth part of the invariant factors starts(via local and rank):" << std::endl;
 		int order = (int)(A. rowdim() < A. coldim() ? A. rowdim() : A. coldim());
-		linbox_check (s. size() >= (unsigned long)order);
+		linbox_check (s. size() >= (size_t)order);
 		std::vector<int64_t>::const_iterator sev_p; const int64_t* prime_p; BlasVector<Givaro::ZRing<Integer> >::iterator s_p;
 		BlasVector<Givaro::ZRing<Integer> > local(Z,(size_t)order);
 		BlasVector<Givaro::ZRing<Integer> >::iterator local_p;
@@ -273,7 +273,7 @@ namespace LinBox
 		report << "Compuation of the k-rough part f the invariant factors starts(via EGV+ or Iliopolous):\n";
 		int order = (int)(A. rowdim() < A. coldim() ? A. rowdim() : A. coldim());
 		integer T; T = order; T <<= 20; T = pow (T, (int) sqrt((double)order));
-		linbox_check ((s. size() >= (unsigned long)order) && (m > 0));
+		linbox_check ((s. size() >= (size_t)order) && (m > 0));
 		if (m == 1)
 			report << "   Not rough part." << std::endl;
 		else if ( m <=  FieldTraits< PIRModular<int32_t> >::maxModulus() ) {
@@ -341,7 +341,7 @@ namespace LinBox
 		std::ostream& report = commentator().report (Commentator::LEVEL_IMPORTANT, PROGRESS_REPORT);
 		report << "Computation the local smith form at each possible prime:\n";
 		int order = (int)(A. rowdim() < A. coldim() ? A. rowdim() : A. coldim());
-		linbox_check (s. size() >= (unsigned long)order);
+		linbox_check (s. size() >= (size_t)order);
 
 		std::vector<int64_t>::const_iterator sev_p;
 		const int64_t* prime_p;
@@ -404,7 +404,7 @@ namespace LinBox
 		int order = (A. rowdim() < A. coldim()) ? (int)A. rowdim() : (int)A. coldim();
 		report << "Computation of the rank starts:\n";
 		typedef typename Matrix::Field Ring;
-		unsigned long r;
+		size_t r;
 		MatrixRank<Ring, Givaro::Modular<int32_t> > MR;
 		r = MR. rank (A);
 		report << "   Matrix rank over a random prime field: " << r << '\n';
@@ -414,7 +414,7 @@ namespace LinBox
 
 		report <<"   Compute the degree of min poly of AA^T: \n";
 		typedef Givaro::Modular<int32_t> Field;
-		integer Val; Field::Element v; unsigned long degree;
+		integer Val; Field::Element v; size_t degree;
         PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(A.coldim()));
 		Field F (*genprime);
 		typename MatrixHomTrait<Matrix, Field>::value_type Ap(F, A.rowdim(), A.coldim());
@@ -526,9 +526,9 @@ namespace LinBox
 
 		report << "Computation of the rank starts:" << std::endl;
 		typedef typename BlasMatrix<IRing,_Rep>::Field Ring;
-		unsigned long r;
+		size_t r;
 		MatrixRank<Ring, Givaro::Modular<int32_t> > MR;
-		r = (unsigned long)MR. rank (A);
+		r = (size_t)MR. rank (A);
 		report << "   Matrix rank over a random prime field: " << r << std::endl;
 		report << "Computation of the rank finished.\n";
 		// a hack
@@ -539,7 +539,7 @@ namespace LinBox
 		report <<"   Compute the degree of min poly of AA^T: \n";
 		typedef Givaro::Modular<int32_t> Field;
 		integer Val; Field::Element v; size_t degree;
-		//integer Val; Field::Element v; unsigned long degree;
+		//integer Val; Field::Element v; size_t degree;
         PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(A.coldim()));
 		Field F (*genprime);
 		typename MatrixHomTrait<BlasMatrix <IRing, _Rep>, Field>::value_type Ap(F,A.rowdim(),A.coldim());

--- a/linbox/algorithms/smith-form-sparseelim-local.h
+++ b/linbox/algorithms/smith-form-sparseelim-local.h
@@ -147,32 +147,32 @@ namespace LinBox
             // Pivot Searchers and column strategy
             // ------------------------------------------------
         template<class Modulo, class Vecteur, class D>
-        void SameColumnPivoting(Modulo PRIME,  const Vecteur& lignepivot, unsigned long& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {}
+        void SameColumnPivoting(Modulo PRIME,  const Vecteur& lignepivot, size_t& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {}
 
 
         template<class Modulo, class Vecteur, class D>
-        void SameColumnPivoting(Modulo PRIME,  const Vecteur& lignepivot, unsigned long& indcol, long& indpermut, D& columns, Boolean_Trait<true>::BooleanType ) {
+        void SameColumnPivoting(Modulo PRIME,  const Vecteur& lignepivot, size_t& indcol, long& indpermut, D& columns, Boolean_Trait<true>::BooleanType ) {
                 // Try first in the same column
-			unsigned long nj = (unsigned long)  lignepivot.size() ;
+			size_t nj = (size_t)  lignepivot.size() ;
 			if (nj && (indcol == lignepivot[0].first) && (! this->MY_divides(PRIME,lignepivot[0].second) ) ) {
                 indpermut = (long) indcol;
-                for(unsigned long j=nj;j--;)
+                for(size_t j=nj;j--;)
                     --columns[ lignepivot[(size_t)j].first ];
                 ++indcol;
             }
         }
 
         template<class Modulo, class BB, class Mmap, class D>
-        bool SameColumnPivotingTrait(Modulo PRIME, unsigned long& p, const BB& LigneA, const Mmap& psizes, unsigned long& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {
+        bool SameColumnPivotingTrait(Modulo PRIME, size_t& p, const BB& LigneA, const Mmap& psizes, size_t& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {
                 // Do not try first in the same column
             return false;
         }
 
         template<class Modulo, class BB, class Mmap, class D>
-        bool SameColumnPivotingTrait(Modulo PRIME, unsigned long& p, const BB& LigneA, const Mmap& psizes, unsigned long& indcol, long& c, D& columns, Boolean_Trait<true>::BooleanType truetrait) {
+        bool SameColumnPivotingTrait(Modulo PRIME, size_t& p, const BB& LigneA, const Mmap& psizes, size_t& indcol, long& c, D& columns, Boolean_Trait<true>::BooleanType truetrait) {
             c=-2;
             for( typename Mmap::const_iterator iter = psizes.begin(); iter != psizes.end(); ++iter) {
-                p = (unsigned long)(*iter).second;
+                p = (size_t)(*iter).second;
                 SameColumnPivoting(PRIME, LigneA[(size_t)p], indcol, c, columns, truetrait ) ;
                 if (c > -2 ) break;
             }
@@ -184,7 +184,7 @@ namespace LinBox
         }
 
 		template<class Modulo, class Vecteur, class D>
-		void CherchePivot(Modulo PRIME, Vecteur& lignepivot, unsigned long& indcol , long& indpermut, D& columns ) {
+		void CherchePivot(Modulo PRIME, Vecteur& lignepivot, size_t& indcol , long& indpermut, D& columns ) {
             long nj =(long)  lignepivot.size() ;
             if (nj) {
                 indpermut = (long)lignepivot[0].first;
@@ -237,8 +237,8 @@ namespace LinBox
 
 		template<class Vecteur>
 		void PermuteColumn(Vecteur& lignecourante,
-                           const unsigned long& nj,
-                           const unsigned long& k,
+                           const size_t& nj,
+                           const size_t& k,
                            const long& indpermut) {
 
             REQUIRE( nj > 0 );
@@ -246,11 +246,11 @@ namespace LinBox
 
                 // Find first non-zero element whose index is
                 // greater than required permutation, if it exists
-            unsigned long j_head(0);
+            size_t j_head(0);
             for(; j_head<nj; ++j_head)
                 if (long(lignecourante[(size_t)j_head].first) >= indpermut) break;
             if ((j_head<nj) && (long(lignecourante[(size_t)j_head].first) == indpermut)) {
-                unsigned long l(0);
+                size_t l(0);
                 for(; l<j_head; ++l)
                     if (lignecourante[(size_t)l].first >= k) break;
                     // -------------------------------------------
@@ -264,21 +264,21 @@ namespace LinBox
                         // zero <--> non zero
                     auto tmp = lignecourante[(size_t)j_head];
                     tmp.first = (k);
-                    for(unsigned long ll=j_head; ll>l; ll--)
+                    for(size_t ll=j_head; ll>l; ll--)
                         lignecourante[ll] = lignecourante[ll-1];
                     lignecourante[l] = tmp;
                 }                
             } else {
                     // -------------------------------------------
                     // Permutation
-                unsigned long l(0);
+                size_t l(0);
                 for(; l<nj; ++l)
                     if (lignecourante[(size_t)l].first >= k) break;
                 if ((l<nj) && (lignecourante[(size_t)l].first == k))  {
                         // non zero <--> zero
                     auto tmp = lignecourante[(size_t)l];
-                    tmp.first = (unsigned long) (indpermut);
-                    const unsigned long bjh(j_head-1);  // Position before j_head
+                    tmp.first = (size_t) (indpermut);
+                    const size_t bjh(j_head-1);  // Position before j_head
                     for(;l<bjh;l++)
                         lignecourante[(size_t)l] = lignecourante[(size_t)l+1];
                     lignecourante[bjh] = tmp;
@@ -290,20 +290,20 @@ namespace LinBox
 
         template<class SpMat>
         void PermuteSubMatrix(SpMat& LigneA,
-							  const unsigned long & start, const unsigned long & stop,
-							  const unsigned long & currentrank, const long & c) {
-			for(unsigned long l=start; l < stop; ++l)
+							  const size_t & start, const size_t & stop,
+							  const size_t & currentrank, const long & c) {
+			for(size_t l=start; l < stop; ++l)
 				if ( LigneA[(size_t)l].size() )
 					PermuteColumn(LigneA[(size_t)l], LigneA[(size_t)l].size(), currentrank, c);
 		}
 
         template<class SpMat>
-        void PermuteUpperMatrix(SpMat& LigneA, const unsigned long & k, const unsigned long & currentrank, const long & c, Boolean_Trait<true>::BooleanType ) {
+        void PermuteUpperMatrix(SpMat& LigneA, const size_t & k, const size_t & currentrank, const long & c, Boolean_Trait<true>::BooleanType ) {
 			PermuteSubMatrix(LigneA, 0, k, currentrank, c);
 		}
 
         template<class SpMat>
-        void PermuteUpperMatrix(SpMat&, const unsigned long &, const unsigned long &, const long &, Boolean_Trait<false>::BooleanType ) {}
+        void PermuteUpperMatrix(SpMat&, const size_t &, const size_t &, const long &, Boolean_Trait<false>::BooleanType ) {}
 
 
         template<class Vecteur>
@@ -320,7 +320,7 @@ namespace LinBox
                                Vecteur& lignecourante,
                                const Vecteur& lignepivot,
                                const typename Signed_Trait<Modulo>::unsigned_type& invpiv,
-                               const unsigned long& k,
+                               const size_t& k,
                                const long& indpermut,
                                De& columns) {
 
@@ -331,20 +331,20 @@ namespace LinBox
 
 			typedef typename Signed_Trait<Modulo>::unsigned_type UModulo;
 
-			unsigned long nj = (unsigned long)  lignecourante.size() ;
+			size_t nj = (size_t)  lignecourante.size() ;
 			if (nj) {
                 if (lignecourante[0].first == k) {
                         // -------------------------------------------
                         // Elimination
-					unsigned long npiv = (unsigned long) lignepivot.size();
+					size_t npiv = (size_t) lignepivot.size();
 					Vecteur construit(nj + npiv);
                         // construit : <-- ci
                         // courante  : <-- m
                         // pivot     : <-- l
 					typedef typename Vecteur::iterator Viter;
 					Viter ci = construit.begin();
-					unsigned long m=1;
-					unsigned long l(0);
+					size_t m=1;
+					size_t l(0);
  
 					F headcoeff = MOD-(lignecourante[0].second);
 					headcoeff *= invpiv;
@@ -356,8 +356,8 @@ namespace LinBox
 						if (lignepivot[(size_t)l].first > k) break;
                         // for all j such that (j>k) and A[(size_t)k,j]!=0
 					for(;l<npiv;++l) {
-						unsigned long j_piv;
-						j_piv = (unsigned long) lignepivot[(size_t)l].first;
+						size_t j_piv;
+						j_piv = (size_t) lignepivot[(size_t)l].first;
                             // if A[(size_t)k,j]=0, then A[(size_t)i,j] <-- A[(size_t)i,j]
 						for (;(m<nj) && (lignecourante[(size_t)m].first < j_piv);)
 							*ci++ = lignecourante[(size_t)m++];
@@ -422,7 +422,7 @@ namespace LinBox
                 for(jj=0; jj<Ni; ++jj) {
                     Vecteur tmp = LigneA[(size_t)jj];
                     Vecteur toto(tmp.size());
-                    unsigned long k=0,rs=0;
+                    size_t k=0,rs=0;
                     for(; k<tmp.size(); ++k) {
                         Modulo r = tmp[(size_t)k].second;
                         if ((r <0) || (r >= MOD)) r %= MOD ;
@@ -440,19 +440,19 @@ namespace LinBox
 
                 }
 
-                unsigned long last = Ni-1;
+                size_t last = Ni-1;
                 long c(0);
-                unsigned long indcol(0);
-                unsigned long ind_pow = 1;
-                unsigned long maxout = Ni/100; maxout = (maxout<10 ? 10 : (maxout>1000 ? 1000 : maxout) );
-                unsigned long thres = Ni/maxout; thres = (thres >0 ? thres : 1);
+                size_t indcol(0);
+                size_t ind_pow = 1;
+                size_t maxout = Ni/100; maxout = (maxout<10 ? 10 : (maxout>1000 ? 1000 : maxout) );
+                size_t thres = Ni/maxout; thres = (thres >0 ? thres : 1);
 
 
-                for (unsigned long k=0; k<last;++k) {
+                for (size_t k=0; k<last;++k) {
                     if ( ! (k % maxout) ) commentator().progress ((long)k);
 
 
-                    unsigned long p=k;
+                    size_t p=k;
                     for(;;) {
 
 
@@ -471,15 +471,15 @@ namespace LinBox
                             break;
 
                         for( typename std::multimap< long, long >::const_iterator iter = psizes.begin(); iter != psizes.end(); ++iter) {
-                            p = (unsigned long)(*iter).second;
+                            p = (size_t)(*iter).second;
 
                             CherchePivot( PRIME, LigneA[(size_t)p], indcol, c , col_density) ;
                             if (c > -2 ) break;
                         }
 
                         if (c > -2) break;
-                        for(unsigned long ii=k;ii<Ni;++ii)
-                            for(unsigned long jjj=LigneA[(size_t)ii].size();jjj--;)
+                        for(size_t ii=k;ii<Ni;++ii)
+                            for(size_t jjj=LigneA[(size_t)ii].size();jjj--;)
                                 LigneA[(size_t)ii][(size_t)jjj].second /= PRIME;
                         MOD /= PRIME;
                         ranks.push_back( indcol );
@@ -500,7 +500,7 @@ namespace LinBox
                     }
                     if (c != -1) {
                         REQUIRE( indcol > 0);
-                        const unsigned long currentrank(indcol-1); 
+                        const size_t currentrank(indcol-1); 
                         if (c != (long)currentrank) {
 #ifdef  LINBOX_pp_gauss_steps_OUT
                             std::cerr << "------------ permuting cols " << (indcol-1) << " and " << c << " ---" << std::endl;
@@ -514,7 +514,7 @@ namespace LinBox
                         UModulo invpiv; 
                         MY_Zpz_inv(invpiv, LigneA[(size_t)k][0].second, MOD);
 
-                        for(unsigned long l=k + 1; (l < Ni) && (col_density[currentrank]); ++l)
+                        for(size_t l=k + 1; (l < Ni) && (col_density[currentrank]); ++l)
                             FaireElimination(MOD, LigneA[(size_t)l], LigneA[(size_t)k], invpiv, currentrank, c, col_density);
                     }
                 
@@ -537,7 +537,7 @@ namespace LinBox
                     CherchePivot( PRIME, LigneA[(size_t)last], indcol, c, col_density );
                 }
                 if (c != -1) {
-                    const unsigned long currentrank(indcol-1);
+                    const size_t currentrank(indcol-1);
                     if (c != (long)currentrank) {
 #ifdef  LINBOX_pp_gauss_steps_OUT
                         std::cerr << "------------ permuting cols " << (indcol-1) << " and " << c << " ---" << std::endl;

--- a/linbox/algorithms/smith-form-sparseelim-poweroftwo.h
+++ b/linbox/algorithms/smith-form-sparseelim-poweroftwo.h
@@ -116,28 +116,28 @@ namespace LinBox
             // Pivot Searchers and column strategy
             // ------------------------------------------------
         template<class Vecteur, class D>
-        void SameColumnPivoting(const Vecteur& lignepivot, unsigned long& indcol, long& indpermut, D& columns, Boolean_Trait<true>::BooleanType ) {
+        void SameColumnPivoting(const Vecteur& lignepivot, size_t& indcol, long& indpermut, D& columns, Boolean_Trait<true>::BooleanType ) {
                 // Try first in the same column
-            unsigned long nj = (unsigned long) lignepivot.size() ;
+            size_t nj = (size_t) lignepivot.size() ;
             if (nj && (indcol == lignepivot[0].first) && (this->isOdd((UInt_t)lignepivot[0].second) ) ) {
                 indpermut = (long)indcol;
-                for(unsigned long j=nj;j--;)
+                for(size_t j=nj;j--;)
                     --columns[ lignepivot[(size_t)j].first ];
                 ++indcol;
             }
         }
 
         template<class BB, class Mmap, class D>
-        bool SameColumnPivotingTrait(unsigned long& p, const BB& LigneA, const Mmap& psizes, unsigned long& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {
+        bool SameColumnPivotingTrait(size_t& p, const BB& LigneA, const Mmap& psizes, size_t& indcol, long& indpermut, D& columns, Boolean_Trait<false>::BooleanType ) {
                 // Do not try first in the same column
             return false;
         }
 
         template<class BB, class Mmap, class D>
-        bool SameColumnPivotingTrait(unsigned long& p, const BB& LigneA, const Mmap& psizes, unsigned long& indcol, long& c, D& columns, Boolean_Trait<true>::BooleanType truetrait) {
+        bool SameColumnPivotingTrait(size_t& p, const BB& LigneA, const Mmap& psizes, size_t& indcol, long& c, D& columns, Boolean_Trait<true>::BooleanType truetrait) {
             c=-2;
             for( typename Mmap::const_iterator iter = psizes.begin(); iter != psizes.end(); ++iter) {
-                p = (unsigned long) (*iter).second;
+                p = (size_t) (*iter).second;
                 SameColumnPivoting(LigneA[(size_t)p], indcol, c, columns, truetrait ) ;
                 if (c > -2 ) break;
             }
@@ -149,7 +149,7 @@ namespace LinBox
         }
 
         template<class Vecteur, class D>
-        void CherchePivot(Vecteur& lignepivot, unsigned long& indcol , long& indpermut, D& columns ) {
+        void CherchePivot(Vecteur& lignepivot, size_t& indcol , long& indpermut, D& columns ) {
             typedef typename Vecteur::value_type E;
             long nj =  (long) lignepivot.size() ;
             if (nj) {
@@ -197,20 +197,20 @@ namespace LinBox
 
         template<class Vecteur>
         void PermuteColumn(Vecteur& lignecourante,
-                           const unsigned long& nj,
-                           const unsigned long& k,
+                           const size_t& nj,
+                           const size_t& k,
                            const long& indpermut) {
             REQUIRE( nj > 0 );
             REQUIRE( indpermut > (long)k );
 
                 // Find first non-zero element whose index is
                 // greater than required permutation, if it exists
-            unsigned long j_head(0);
+            size_t j_head(0);
             for(; j_head<nj; ++j_head)
                 if (long(lignecourante[(size_t)j_head].first) >= indpermut) break;
 
             if ((j_head<nj) && (long(lignecourante[(size_t)j_head].first) == indpermut)) {
-                unsigned long l(0);
+                size_t l(0);
                 for(; l<j_head; ++l)
                     if (lignecourante[(size_t)l].first >= k) break;
                 if (l<j_head && lignecourante[l].first == k) {
@@ -222,21 +222,21 @@ namespace LinBox
                         // zero <--> non zero
                     auto tmp = lignecourante[(size_t)j_head];
                     tmp.first = (k);
-                    for(unsigned long ll=j_head; ll>l; ll--)
+                    for(size_t ll=j_head; ll>l; ll--)
                         lignecourante[ll] = lignecourante[ll-1];
                     lignecourante[l] = tmp;
                 }
             } else {
                     // -------------------------------------------
                     // Permutation
-                unsigned long l(0);
+                size_t l(0);
                 for(; l<nj; ++l)
                     if (lignecourante[(size_t)l].first >= k) break;
                 if ((l<nj) && (lignecourante[(size_t)l].first == k)) {
                         // non zero <--> zero
                     auto tmp = lignecourante[(size_t)l];
-                    tmp.first = (unsigned long)(indpermut);
-					const unsigned long bjh(j_head-1); // Position before j_head
+                    tmp.first = (size_t)(indpermut);
+					const size_t bjh(j_head-1); // Position before j_head
                     for(;l<bjh;l++)
                         lignecourante[(size_t)l] = lignecourante[(size_t)l+1];
                     lignecourante[bjh] = tmp;
@@ -255,48 +255,48 @@ namespace LinBox
 
         template<class SpMat>
         void PermuteSubMatrix(SpMat& LigneA,
-							  const unsigned long & start,
-                              const unsigned long & stop,
-							  const unsigned long & currentrank,
+							  const size_t & start,
+                              const size_t & stop,
+							  const size_t & currentrank,
                               const long & c) {
-			for(unsigned long l=start; l < stop; ++l)
+			for(size_t l=start; l < stop; ++l)
 				if ( LigneA[(size_t)l].size() )
 					PermuteColumn(LigneA[(size_t)l], LigneA[(size_t)l].size(), currentrank, c);
 		}
 
         template<class SpMat>
-        void PermuteUpperMatrix(SpMat& LigneA, const unsigned long & k, const unsigned long & currentrank, const long & c, Boolean_Trait<true>::BooleanType ) {
+        void PermuteUpperMatrix(SpMat& LigneA, const size_t & k, const size_t & currentrank, const long & c, Boolean_Trait<true>::BooleanType ) {
 			PermuteSubMatrix(LigneA, 0, k, currentrank, c);
 		}
 
         template<class SpMat>
-        void PermuteUpperMatrix(SpMat&, const unsigned long &, const unsigned long &, const long &, Boolean_Trait<false>::BooleanType ) {}
+        void PermuteUpperMatrix(SpMat&, const size_t &, const size_t &, const long &, Boolean_Trait<false>::BooleanType ) {}
 
         template<class Vecteur, class De>
         void FaireElimination( const size_t EXPONENT, const UInt_t& TWOK, const UInt_t& TWOKMONE,
                                Vecteur& lignecourante,
                                const Vecteur& lignepivot,
                                const UInt_t& invpiv,
-                               const unsigned long& k,
+                               const size_t& k,
                                const long& indpermut,
                                De& columns) {
 
             typedef typename Vecteur::value_type E;
 
-            unsigned long nj = (unsigned long) lignecourante.size() ;
+            size_t nj = (size_t) lignecourante.size() ;
 
             if (nj) {
                 if (lignecourante[0].first == k) {
                         // -------------------------------------------
                         // Head non-zero ==> Elimination
-                    unsigned long npiv = (unsigned long) lignepivot.size();
+                    size_t npiv = (size_t) lignepivot.size();
                     Vecteur construit(nj + npiv);
                         // construit : <-- ci
                         // courante  : <-- m
                         // pivot     : <-- l
                     auto ci = construit.begin();
-                    unsigned long m=1;
-                    unsigned long l(0);
+                    size_t m=1;
+                    size_t l(0);
 
                         // A[(size_t)i,k] <-- A[(size_t)i,k] / A[(size_t)k,k]
                     UInt_t headcoeff = TWOK-(UInt_t)(lignecourante[0].second);
@@ -309,8 +309,8 @@ namespace LinBox
                         if (lignepivot[(size_t)l].first > k) break;
                         // for all j such that (j>k) and A[(size_t)k,j]!=0
                     for(;l<npiv;++l) {
-                        unsigned long j_piv;
-                        j_piv = (unsigned long) lignepivot[(size_t)l].first;
+                        size_t j_piv;
+                        j_piv = (size_t) lignepivot[(size_t)l].first;
                             // if A[(size_t)k,j]=0,
                             // then A[(size_t)i,j] <-- A[(size_t)i,j]
                         for (;(m<nj) && (lignecourante[(size_t)m].first < j_piv);)
@@ -393,19 +393,19 @@ namespace LinBox
                     LigneA[(size_t)jj] = toto;
                 }
 
-                unsigned long last = Ni-1;
+                size_t last = Ni-1;
                 long c(0);
-                unsigned long indcol(0);
-                unsigned long ind_pow = 1;
-                unsigned long maxout = Ni/100; maxout = (maxout<10 ? 10 : (maxout>1000 ? 1000 : maxout) );
-                unsigned long thres = Ni/maxout; thres = (thres >0 ? thres : 1);
+                size_t indcol(0);
+                size_t ind_pow = 1;
+                size_t maxout = Ni/100; maxout = (maxout<10 ? 10 : (maxout>1000 ? 1000 : maxout) );
+                size_t thres = Ni/maxout; thres = (thres >0 ? thres : 1);
 
 
-                for (unsigned long k=0; k<last;++k) {
+                for (size_t k=0; k<last;++k) {
                     if ( ! (k % maxout) ) commentator().progress ((long)k);
 
                         // Look for invertible pivot
-                    unsigned long p=k;
+                    size_t p=k;
                     for(;;) {
                             // Order the rows 
                         std::multimap< long, long > psizes;
@@ -423,7 +423,7 @@ namespace LinBox
                             break;
 
                         for(auto const& iter: psizes) {
-                            p = (unsigned long) iter.second;
+                            p = (size_t) iter.second;
 
                             CherchePivot( LigneA[(size_t)p], indcol, c , col_density) ;
                             if (c > -2 ) break;
@@ -433,8 +433,8 @@ namespace LinBox
 
                             // No invertible pivot found
                             // reduce everything by one power of 2
-                        for(unsigned long ii=k;ii<Ni;++ii)
-                            for(unsigned long jjj=LigneA[(size_t)ii].size();jjj--;)
+                        for(size_t ii=k;ii<Ni;++ii)
+                            for(size_t jjj=LigneA[(size_t)ii].size();jjj--;)
                                 LigneA[(size_t)ii][(size_t)jjj].second >>= 1;
 
                         --EXPONENT;
@@ -463,7 +463,7 @@ namespace LinBox
                     if (c != -1) {
                             // Pivot has been found
                         REQUIRE( indcol > 0);
-                        const unsigned long currentrank(indcol-1); 
+                        const size_t currentrank(indcol-1); 
 
                         if (c != (long)currentrank) {
 #ifdef  LINBOX_pp_gauss_steps_OUT
@@ -478,7 +478,7 @@ namespace LinBox
                             // Compute the inverse of the found pivot
                         UInt_t invpiv;
                         MY_Zpz_inv(invpiv, (UInt_t) (LigneA[(size_t)k][0].second), EXPONENT, TWOKMONE);
-                        for(unsigned long l=k + 1; (l < Ni) && (col_density[currentrank]); ++l)
+                        for(size_t l=k + 1; (l < Ni) && (col_density[currentrank]); ++l)
                             FaireElimination(EXPONENT, TWOK, TWOKMONE, LigneA[(size_t)l], LigneA[(size_t)k], invpiv, currentrank, c, col_density);
                     }
                     
@@ -503,7 +503,7 @@ namespace LinBox
                     CherchePivot( LigneA[(size_t)last], indcol, c, col_density );
                 }
                 if (c != -1) {
-                    const unsigned long currentrank(indcol-1);
+                    const size_t currentrank(indcol-1);
                     if (c != (long)currentrank) {
 #ifdef  LINBOX_pp_gauss_steps_OUT
                         std::cerr << "------------ permuting cols " << (indcol-1) << " and " << c << " ---" << std::endl;

--- a/linbox/algorithms/triangular-solve.h
+++ b/linbox/algorithms/triangular-solve.h
@@ -111,7 +111,7 @@ namespace LinBox
 	// first rank rows of U are upper triangular and full rank
 	template <class _Matrix, class Vector1, class Vector2> Vector1&
 	upperTriangularSparseSolve (Vector1& x,
-				    unsigned long rank,
+				    size_t rank,
 				    const _Matrix  &U,
 				    const Vector2& b)
 	{

--- a/linbox/algorithms/varprec-cra-early-multip.h
+++ b/linbox/algorithms/varprec-cra-early-multip.h
@@ -65,10 +65,10 @@ namespace LinBox
 		BlasVector< Givaro::ZRing<Integer> > vfactor_;
 		BlasVector< Givaro::ZRing<Integer> > vmultip_;
 
-		std::vector< unsigned long > randv;
+		std::vector< size_t > randv;
 		Integer& result(Integer &d) {return d;}; // DON'T TOUCH
 	public:
-		VarPrecEarlyMultipCRA(const unsigned long EARLY = DEFAULT_EARLY_TERM_THRESHOLD, const double b=0.0,
+		VarPrecEarlyMultipCRA(const size_t EARLY = DEFAULT_EARLY_TERM_THRESHOLD, const double b=0.0,
 				      const BlasVector<Givaro::ZRing<Integer> >& vf = BlasVector<Givaro::ZRing<Integer> >(Givaro::ZRing<Integer>()),
 				      const BlasVector<Givaro::ZRing<Integer> >& vm = BlasVector<Givaro::ZRing<Integer> >(Givaro::ZRing<Integer>())) :
 			EarlySingleCRA<Domain>(EARLY), FullMultipCRA<Domain>(b), vfactor_(vf), vmultip_(vm)
@@ -116,8 +116,8 @@ namespace LinBox
 			vmultip_.resize( e.size(),1 );
 			randv. resize ( e.size() );
 
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000 - 10000;
+			for ( std::vector<size_t>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
+				*int_p = ((size_t)lrand48()) % 20000 - 10000;
 
 			std::vector<Integer> vz(vfactor_.size());
 			inverse(vz,vfactor_,D);
@@ -138,8 +138,8 @@ namespace LinBox
 			vmultip_.resize( e.size(),1 );
 			randv. resize ( e.size() );
 
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000 - 10000;
+			for ( std::vector<size_t>::iterator int_p = randv. begin(); int_p != randv. end(); ++ int_p)
+				*int_p = ((size_t)lrand48()) % 20000 - 10000;
 
 			std::vector<DomainElement> vz(vfactor_.size());
 			inverse(vz,vfactor_,D);
@@ -496,8 +496,8 @@ namespace LinBox
 		}
 
 		bool changeVector() {
-			for ( std::vector<unsigned long>::iterator int_p = randv. begin();int_p != randv. end(); ++ int_p)
-				*int_p = ((unsigned long)lrand48()) % 20000;
+			for ( std::vector<size_t>::iterator int_p = randv. begin();int_p != randv. end(); ++ int_p)
+				*int_p = ((size_t)lrand48()) % 20000;
 			return changePreconditioner(vfactor_,vmultip_);
 		}
 

--- a/linbox/algorithms/varprec-cra-early-single.h
+++ b/linbox/algorithms/varprec-cra-early-single.h
@@ -62,7 +62,7 @@ namespace LinBox
 		Integer factor_;
 		Integer multip_;
 
-		VarPrecEarlySingleCRA(const unsigned long EARLY = DEFAULT_EARLY_TERM_THRESHOLD
+		VarPrecEarlySingleCRA(const size_t EARLY = DEFAULT_EARLY_TERM_THRESHOLD
 				      , const double b=0.0
 				      , const Integer& f=Integer(1)
 				      , const Integer& m=Integer(1)) :

--- a/linbox/algorithms/wiedemann.h
+++ b/linbox/algorithms/wiedemann.h
@@ -92,7 +92,7 @@ namespace LinBox
 	{
 		typedef typename Blackbox::Field Field;
 		typename Field::RandIter i (A.field());
-		unsigned long            deg;
+		size_t            deg;
 
 		commentator().start ("Wiedemann Minimal polynomial", "minpoly");
 
@@ -306,7 +306,7 @@ namespace LinBox
 					    Vector &x,
 					    const Vector &b,
 					    Vector &u,
-					    unsigned long r);
+					    size_t r);
 
 		/*! Get a random solution to a singular system Ax=b of rank r with
 		 * generic rank profile.

--- a/linbox/algorithms/wiedemann.inl
+++ b/linbox/algorithms/wiedemann.inl
@@ -91,7 +91,7 @@ namespace LinBox
 
 		unsigned int tries = (unsigned int)_traits.maxTries ();
 
-		unsigned long r = (unsigned long) -1;
+		size_t r = (size_t) -1;
 
 		// Dan Roche 6-21-04 Changed this from UNKNOWN which I think was incorrect
 		if (_traits.rank () != WiedemannTraits::RANK_UNKNOWN)
@@ -144,7 +144,7 @@ namespace LinBox
 
 			case WiedemannTraits::SINGULAR:
 				{
-					if (r == (unsigned long) -1) {
+					if (r == (size_t) -1) {
 						rank (r, A);
 						commentator().report (Commentator::LEVEL_IMPORTANT, INTERNAL_DESCRIPTION)
 						<< "Rank of A = " << r << std::endl;
@@ -156,7 +156,7 @@ namespace LinBox
 						break;
 
 					case FAILED:
-						r = (unsigned long) -1;
+						r = (size_t) -1;
 						break;
 
 					case SINGULAR:
@@ -285,7 +285,7 @@ namespace LinBox
 					       Vector               &x,
 					       const Vector         &b,
 					       Vector               &u,
-					       unsigned long         r)
+					       size_t         r)
 	{
 		commentator().start ("Solving singular system (Wiedemann)", "WiedemannSolver::solveSingular");
 
@@ -500,7 +500,7 @@ namespace LinBox
 
 		RandomDenseStream<Field, Vector> stream (field(), _randiter, A.coldim ());
 
-		unsigned long r = (A.coldim () < A.rowdim ()) ? A.coldim () : A.rowdim ();
+		size_t r = (A.coldim () < A.rowdim ()) ? A.coldim () : A.rowdim ();
 
 		VectorWrapper::ensureDim (v, A.coldim ());
 		VectorWrapper::ensureDim (Av, A.rowdim ());

--- a/linbox/solutions/det.h
+++ b/linbox/solutions/det.h
@@ -215,7 +215,7 @@ namespace LinBox
 			commentator().start ("Symmetric Wiedemann Determinant", "sdet");
 			linbox_check (A.coldim () == A.rowdim ());
 			Polynomial               phi(F);
-			unsigned long            deg;
+			size_t            deg;
 			typename Field::RandIter iter (F);
 
 			// Precondition here to separate the eigenvalues, so that
@@ -276,7 +276,7 @@ namespace LinBox
 			linbox_check (A.coldim () == A.rowdim ());
 
 			Polynomial               phi(F);
-			unsigned long            deg;
+			size_t            deg;
 			typename Field::RandIter iter (F);
 
 			// Precondition here to separate the eigenvalues, so that

--- a/linbox/solutions/methods.h
+++ b/linbox/solutions/methods.h
@@ -199,9 +199,9 @@ namespace LinBox
 		SingularState	singular ()		const { return _singular; }
 		bool		symmetric ()		const { return _symmetric; }
 		bool		certificate ()		const { return _certificate; }
-		unsigned long	maxTries ()		const { return _maxTries; }
-		unsigned long	earlyTermThreshold ()	const { return _ett; }
-		unsigned long	blockingFactor ()	const { return _blockingFactor; }
+		size_t	maxTries ()		const { return _maxTries; }
+		size_t	earlyTermThreshold ()	const { return _ett; }
+		size_t	blockingFactor ()	const { return _blockingFactor; }
 		PivotStrategy	strategy ()		const { return _strategy; }
 		Shape		shape ()		const { return _shape; }
 		double		trustability ()		const { return _provensuccessprobability; }
@@ -223,9 +223,9 @@ namespace LinBox
 		void singular       (SingularState s)  { _singular = s; }
 		void symmetric      (bool s)           { _symmetric = s; }
 		void certificate    (bool s)           { _certificate = s; }
-		void maxTries       (unsigned long n)  { _maxTries = n; }
-		void earlyTermThreshold (unsigned long e) { _ett = e; }
-		void blockingFactor (unsigned long b)  { _blockingFactor = b; }
+		void maxTries       (size_t n)  { _maxTries = n; }
+		void earlyTermThreshold (size_t e) { _ett = e; }
+		void blockingFactor (size_t b)  { _blockingFactor = b; }
 		void strategy (PivotStrategy Strategy) { _strategy = Strategy; }
 		void shape          (Shape s)          { _shape = s; }
 		void trustability   (double p)         { _provensuccessprobability = p; }
@@ -241,9 +241,9 @@ namespace LinBox
 		SingularState  _singular;
 		bool           _symmetric;
 		bool           _certificate;
-		unsigned long  _maxTries;
-		unsigned long  _ett;
-		unsigned long  _blockingFactor;
+		size_t  _maxTries;
+		size_t  _ett;
+		size_t  _blockingFactor;
 		PivotStrategy  _strategy;
 		Shape          _shape;
 		double         _provensuccessprobability;
@@ -318,12 +318,12 @@ namespace LinBox
 		 */
 		WiedemannTraits (
 				 bool           Symmetric      = NON_SYMMETRIC,
-				 unsigned long  Thres          = DEFAULT_EARLY_TERM_THRESHOLD,
+				 size_t  Thres          = DEFAULT_EARLY_TERM_THRESHOLD,
 				 size_t         Rank           = RANK_UNKNOWN,
 				 Preconditioner Precond        = SPARSE,
 				 SingularState  Singular       = SINGULARITY_UNKNOWN,
 				 bool           Certificate    = CERTIFY,
-				 unsigned long  MaxTries       = 100,
+				 size_t  MaxTries       = 100,
 				 bool           CheckResult    = true
 				)
 
@@ -347,12 +347,12 @@ namespace LinBox
 	struct WiedemannExtensionTraits : public WiedemannTraits {
 		WiedemannExtensionTraits (
 					  bool           Symmetric      = NON_SYMMETRIC,
-					  unsigned long  Thres          = DEFAULT_EARLY_TERM_THRESHOLD,
+					  size_t  Thres          = DEFAULT_EARLY_TERM_THRESHOLD,
 					  size_t         Rank           = RANK_UNKNOWN,
 					  Preconditioner Precond        = SPARSE,
 					  SingularState  Singular       = SINGULARITY_UNKNOWN,
 					  bool           Certificate    = CERTIFY,
-					  unsigned long  MaxTries       = 100,
+					  size_t  MaxTries       = 100,
 					  bool           CheckResult    = true
 					 ) :
 			WiedemannTraits(Symmetric,Thres,Rank,Precond,Singular,
@@ -372,7 +372,7 @@ namespace LinBox
 		 * returning a failure; default is 100
 		 */
 		LanczosTraits (Preconditioner Precond  = FULL_DIAGONAL,
-			       unsigned long  MaxTries = 100)
+			       size_t  MaxTries = 100)
 		{
 			Specifier::_preconditioner =(Precond);
 			Specifier::_maxTries =(MaxTries);
@@ -392,12 +392,12 @@ namespace LinBox
 		 * @param blockingFactor Blocking factor to use
 		 */
 		BlockLanczosTraits (Preconditioner Precond        = FULL_DIAGONAL,
-				    unsigned long  MaxTries       = 100,
+				    size_t  MaxTries       = 100,
 				    int            BlockingFactor = 16)
 		{
 			Specifier::_preconditioner = (Precond);
 			Specifier::_maxTries       = (MaxTries);
-			Specifier::_blockingFactor = (unsigned long) (BlockingFactor);
+			Specifier::_blockingFactor = (size_t) (BlockingFactor);
 		}
 
 		BlockLanczosTraits( const Specifier& S) :
@@ -437,7 +437,7 @@ namespace LinBox
 			_solution                  = (Solution);
 			Specifier::_singular       = (Singular);
 			Specifier::_certificate    = (Certificate);
-			Specifier::_maxTries       = (unsigned long) (MaxTries);
+			Specifier::_maxTries       = (size_t) (MaxTries);
 			Specifier::_preconditioner = (Precond);
 			Specifier::_rank           = (Rank);
 		}
@@ -554,7 +554,7 @@ namespace LinBox
 	///
 	struct BlasExtensionTraits : public BlasEliminationTraits {
 		BlasExtensionTraits (bool           //certificate    = CERTIFY
-				     , unsigned long  //maxTries       = 100
+				     , size_t  //maxTries       = 100
 				     , bool         //checkResult    = true
 				    ) :
 			BlasEliminationTraits()

--- a/linbox/solutions/rank.h
+++ b/linbox/solutions/rank.h
@@ -72,11 +72,11 @@ namespace LinBox
 	 * \return a reference to r.
 	 */
 	template <class Blackbox, class Method, class DomainCategory>
-	inline unsigned long &rank (unsigned long &r, const Blackbox &A, 
+	inline size_t &rank (size_t &r, const Blackbox &A, 
 			const DomainCategory &tag, const Method &M);
 
 	template <class Blackbox, class Method, class DomainCategory>
-	inline unsigned long &rankin (unsigned long &r, Blackbox &A, 
+	inline size_t &rankin (size_t &r, Blackbox &A, 
 			const DomainCategory &tag, const Method &M);
 
 	/**
@@ -89,7 +89,7 @@ namespace LinBox
 	 * \return     \p r rank of \p A.
 	  */
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long &r, const Blackbox &A)
+	inline size_t &rank (size_t &r, const Blackbox &A)
 	{
 		return rank(r, A, typename FieldTraits<typename Blackbox::Field>::categoryTag(), Method::Hybrid());
 	}
@@ -106,7 +106,7 @@ namespace LinBox
 	 * @param M method (see ???)
 	 */
 	template <class Blackbox, class Method>
-	inline unsigned long &rank (unsigned long &r, const Blackbox &A,
+	inline size_t &rank (size_t &r, const Blackbox &A,
 				    const Method &M)
 	{
 		return rank(r, A, typename FieldTraits<typename Blackbox::Field>::categoryTag(), M);
@@ -118,7 +118,7 @@ namespace LinBox
 	 * @param r rank
 	*/
 	template <class Blackbox>
-	inline unsigned long &rankin (unsigned long &r, Blackbox &A)
+	inline size_t &rankin (size_t &r, Blackbox &A)
 	{
 		//! @bug there is no Elimination() method there.
 		return rankin(r, A, typename FieldTraits<typename Blackbox::Field>::categoryTag(), Method::SparseElimination());

--- a/linbox/solutions/rank.inl
+++ b/linbox/solutions/rank.inl
@@ -41,7 +41,7 @@ namespace LinBox
 
 
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                    &r,
+	inline size_t &rank (size_t                    &r,
 				    const Blackbox                   &A,
 				    const RingCategories::ModularTag &tag,
 				    const Method::Hybrid             &m)
@@ -56,7 +56,7 @@ namespace LinBox
 	}
 
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                     &r,
+	inline size_t &rank (size_t                     &r,
 				    const Blackbox                    &A,
 				    const RingCategories::ModularTag  &tag,
 				    const Method::Elimination         &m)
@@ -71,7 +71,7 @@ namespace LinBox
 	}
 
 	template <class Field, class Vector>
-	inline unsigned long &rank (unsigned long                      &r,
+	inline size_t &rank (size_t                      &r,
 				    const SparseMatrix<Field, Vector>  &A,
 				    const RingCategories::ModularTag   &tag,
 				    const Method::Elimination          &m)
@@ -82,7 +82,7 @@ namespace LinBox
 
 	// specialization of NonBlas for SparseMatrix
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                       &r,
+	inline size_t &rank (size_t                       &r,
 				    const Blackbox                      &A,
 				    const   RingCategories::ModularTag  &tag,
 				    const Method::NonBlasElimination    & m)
@@ -92,7 +92,7 @@ namespace LinBox
 
 	// specialization of NonBlas for SparseMatrix
 	template <class Blackbox>
-	inline unsigned long &rankin (unsigned long                       &r,
+	inline size_t &rankin (size_t                       &r,
 				    Blackbox                      &A,
 				    const   RingCategories::ModularTag  &tag,
 				    const Method::NonBlasElimination    & m)
@@ -102,7 +102,7 @@ namespace LinBox
 
 
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                     &r,
+	inline size_t &rank (size_t                     &r,
 				    const Blackbox                    &A,
 				    const  RingCategories::ModularTag &tag,
 				    const Method::Blackbox            &m);
@@ -111,7 +111,7 @@ namespace LinBox
 
 	/// M may be <code>Method::Wiedemann()</code>.
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                     &res,
+	inline size_t &rank (size_t                     &res,
 				    const Blackbox                    &A,
 				    const RingCategories::ModularTag  &tag,
 				    const Method::Wiedemann           &M)
@@ -151,8 +151,8 @@ namespace LinBox
 			trace(t, B);
 			if (phi.size() >= 2) F.neg(p2, phi[ phi.size()-2]);
 
-			int nbperm = 0; unsigned long rk;
-			int logn = (int)(2*(unsigned long)floor( log( (double)A.rowdim() ) ));
+			int nbperm = 0; size_t rk;
+			int logn = (int)(2*(size_t)floor( log( (double)A.rowdim() ) ));
 			bool tryagain = (! F.areEqual( t, p2 ));
 			while( tryagain ) {
 				commentator().stop ("fail", NULL, "trace");
@@ -293,8 +293,8 @@ namespace LinBox
 			WhisartTraceTranspose(t, F, D1_i, A, D2_i);
 			if (phi.size() >= 2) F.neg(p2, phi[ phi.size()-2]);
 
-			int nbperm = 0; unsigned long rk;
-			int logn = (int)(2*(unsigned long)floor( log( (double)A.rowdim() ) ));
+			int nbperm = 0; size_t rk;
+			int logn = (int)(2*(size_t)floor( log( (double)A.rowdim() ) ));
 			bool tryagain = (! F.areEqual( t, p2 ));
 			while( tryagain ) {
 				commentator().stop ("fail", NULL, "trace");
@@ -394,8 +394,8 @@ namespace LinBox
 	}
 
 	template <class Field>
-	inline unsigned long &rankin (
-        unsigned long       &r,
+	inline size_t &rankin (
+        size_t       &r,
         SparseMatrix<Field, SparseMatrixFormat::SparseSeq>  &A,
         const RingCategories::ModularTag  &tag,
         const Method::Elimination         &m)
@@ -406,7 +406,7 @@ namespace LinBox
 
 	/// M may be <code>Method::SparseElimination()</code>.
 	template <class Field>
-	inline unsigned long &rank (unsigned long                       &r,
+	inline size_t &rank (size_t                       &r,
 				    const SparseMatrix<Field, SparseMatrixFormat::SparseSeq>  &A,
 				    const RingCategories::ModularTag    &tag,
 				    const Method::SparseElimination     &M)
@@ -418,7 +418,7 @@ namespace LinBox
 
 	// Change of representation to be able to call the sparse elimination
 	template <class Blackbox, class DomainCategory>
-	inline unsigned long &rank (unsigned long                       &r,
+	inline size_t &rank (size_t                       &r,
 				    const Blackbox                      &A,
 				    const DomainCategory		&tag,
 				    const Method::SparseElimination     &M)
@@ -431,7 +431,7 @@ namespace LinBox
 
 	// M may be <code>Method::BlasElimination()</code>.
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                      &r,
+	inline size_t &rank (size_t                      &r,
 				    const Blackbox                     &A,
 				    const RingCategories::ModularTag   &tag,
 				    const Method::BlasElimination      &M)
@@ -452,7 +452,7 @@ namespace LinBox
 
 
 	template <class Blackbox, class MyMethod>
-	inline unsigned long &integral_rank (unsigned long	&r,
+	inline size_t &integral_rank (size_t	&r,
                                          const Blackbox	&A,
                                          const MyMethod	&M)
 	{
@@ -476,7 +476,7 @@ namespace LinBox
 
 
 	template <class Blackbox, class MyMethod>
-	inline unsigned long &rank (unsigned long                     &r,
+	inline size_t &rank (size_t                     &r,
 				    const Blackbox                    &A,
 				    const RingCategories::IntegerTag  &tag,
 				    const MyMethod                    &M)
@@ -486,7 +486,7 @@ namespace LinBox
 
 	// error hanlder for rational domain
 	template <class Blackbox, class Method>
-	inline unsigned long &rank (unsigned long                           &r,
+	inline size_t &rank (size_t                           &r,
 				    const Blackbox                          &A,
 				    const RingCategories::RationalTag     &tag,
 				    const Method                           &M)
@@ -501,7 +501,7 @@ namespace LinBox
 
 	// More specialized to avoid ambiguity and force rational rank
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long           &r,
+	inline size_t &rank (size_t           &r,
 				    const Blackbox                      &A,
 				    const RingCategories::RationalTag   &tag,
 				    const Method::SparseElimination     &M)
@@ -521,7 +521,7 @@ namespace LinBox
 namespace LinBox
 {
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                     &r,
+	inline size_t &rank (size_t                     &r,
 				    const Blackbox                    &A,
 				    const RingCategories::ModularTag  &tag,
 				    const Method::Blackbox            & m)
@@ -566,7 +566,7 @@ namespace LinBox
 /*namespace LinBox
 {
 	template <class Blackbox>
-	inline unsigned long &rank (unsigned long                      &r,
+	inline size_t &rank (size_t                      &r,
 				    const Blackbox                     &A,
 				    const  RingCategories::ModularTag  &tag,
 				    const Method::Blackbox             & m)
@@ -578,7 +578,7 @@ namespace LinBox
 namespace LinBox { /*  rankin */
 
 	template <class Field, class Method>
-	inline unsigned long &rankin (unsigned long                   &r,
+	inline size_t &rankin (size_t                   &r,
 				      SparseMatrix<Field, SparseMatrixFormat::SparseSeq>  &A,
 				      const Method                    &M)
 	{
@@ -587,7 +587,7 @@ namespace LinBox { /*  rankin */
 
 
 	template <class Blackbox, class Ring>
-	inline unsigned long &rankin (unsigned long                       &r,
+	inline size_t &rankin (size_t                       &r,
 				      Blackbox                            &A,
 				      const RingCategories::IntegerTag    &tag,
 				      const Method::SparseElimination     &M)
@@ -605,7 +605,7 @@ namespace LinBox { /*  rankin */
 	}
 
 	/// specialization to \f$ \mathbf{F}_2 \f$
-	inline unsigned long &rankin (unsigned long                       &r,
+	inline size_t &rankin (size_t                       &r,
 				      GaussDomain<GF2>::Matrix            &A,
 				      const Method::SparseElimination     &)//M
 	{
@@ -617,7 +617,7 @@ namespace LinBox { /*  rankin */
 	}
 
 	/// specialization to \f$ \mathbf{F}_2 \f$
-	inline unsigned long &rankin (unsigned long                       &r,
+	inline size_t &rankin (size_t                       &r,
 				      GaussDomain<GF2>::Matrix            &A,
 				      const RingCategories::ModularTag    &,//tag
 				      const Method::SparseElimination     &M)
@@ -628,7 +628,7 @@ namespace LinBox { /*  rankin */
 
 	/// A is modified.
 	template <class Field>
-	inline unsigned long &rankin (unsigned long                     &r,
+	inline size_t &rankin (size_t                     &r,
 				      BlasMatrix<Field>               &A,
 				      const RingCategories::ModularTag  &tag,
 				      const Method::BlasElimination     &M)
@@ -643,7 +643,7 @@ namespace LinBox { /*  rankin */
 	}
 
 	template <class Field>
-	inline unsigned long &rankin (unsigned long       &r,
+	inline size_t &rankin (size_t       &r,
 				      BlasMatrix<Field>               &A,
 				    const RingCategories::ModularTag  &tag,
 				    const Method::Elimination         &m)
@@ -656,7 +656,7 @@ namespace LinBox { /*  rankin */
 
 
 	template <class Blackbox>
-	inline unsigned long &rankin (unsigned long                    &r,
+	inline size_t &rankin (size_t                    &r,
 				    Blackbox                   &A,
 				    const RingCategories::ModularTag &tag,
 				    const Method::Hybrid             &m)
@@ -667,7 +667,7 @@ namespace LinBox { /*  rankin */
 
 	// A is modified.
 	template <class Blackbox>
-	inline unsigned long &rankin (unsigned long                      &r,
+	inline size_t &rankin (size_t                      &r,
 				      Blackbox                             &A,
 				      const RingCategories::ModularTag   &tag,
 				      const Method::SparseElimination    &M)

--- a/linbox/vector/blas-vector.h
+++ b/linbox/vector/blas-vector.h
@@ -182,49 +182,12 @@ namespace LinBox { /* BlasVector */
 			// linbox_check(_ptr != NULL);
 		}
 
-// #if 0
-// 		void init(const _Field & F, size_t n = 0)
-// 		{
-// 			_field = &F;
-// 			_size = n;
-// 			_1stride=1 ;
-// 			_rep.resize(n, F.zero);
-// 			_ptr = _rep.data();
-// 		}
-// #endif
 
-// #ifdef __GNUC__
-// #ifndef __x86_64__
-// #if (__GNUC__ == 4 && __GNUC_MINOR__ ==4 && __GNUC_PATCHLEVEL__==5)
-// 		BlasVector (const _Field &F, const long &m, const Element e=Element()) :
-// 			Father_t(),
-// 			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-// 		{
-// 			// Father_t is garbage until then:
-// 			setIterators();
-
-// 			linbox_check(_size==0 || _ptr != NULL);
-// 		}
-// #endif
-// #endif
-// #endif
-
-// #if defined(__APPLE__) || (defined(__s390__) && !defined(__s390x__))
-// 		BlasVector (const _Field &F, const unsigned long &m, const Element e=Element())  :
-// 			Father_t(),
-// 			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-// 		{
-// 			// Father_t is garbage until then:
-// 			setIterators();
-
-// 			linbox_check(_size==0 || _ptr != NULL);
-
-// 			// linbox_check(_size >= this->begin()->_stride); PG -> do not understand
-// 		}
-
-// #endif
-
-		BlasVector (const _Field &F, const size_t &m, const Element e=Element())  :
+            // This constructor is templated because if SizeType was a size_t, then calling it with a signed const litteral 
+            // (e.g. v(F,3)) would fail to launch this constructor, but rather go in the templated one (_Field, VectorBase) 
+            // on OSX where long can not be cast to size_t).
+        template<class SizeType, typename std::enable_if<std::is_arithmetic<SizeType>::value, int>::type=0>
+		BlasVector (const _Field &F, const SizeType &m, const Element e=Element())  :
 			Father_t(),
 			_size(m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
 		{
@@ -232,56 +195,6 @@ namespace LinBox { /* BlasVector */
 			setIterators();
 			// linbox_check(_ptr != NULL);
 		}
-
-
-	// 	BlasVector (const _Field &F, const int64_t &m, const Element e=Element())  :
-	// 		Father_t(),
-	// 		_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
-	// 	{
-	// // Father_t is garbage until then:
-	// 		setIterators();
-
-
-	// 		linbox_check(_size==0 || _ptr != NULL);
-	// 	}
-
-
-	// 	BlasVector (const _Field &F, const uint32_t &m, const Element e=Element())  :
-	// 		Father_t(),
-	// 		_size((size_t)m),
-	// 		_1stride(1),
-	// 		_rep((size_t)_size, e),
-	// 		_ptr(_rep.data()),
-	// 		_field(&F)
-	// 	{
-	// // Father_t is garbage until then:
-	// 		setIterators();
-
-
-	// 		linbox_check(_size==0 || _ptr != NULL);
-	// 	}
-
-	// 	BlasVector (const _Field &F, const int32_t &m, const Element e=Element())  :
-	// 		Father_t(),
-	// 		_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
-	// 	{
-	// // Father_t is garbage until then:
-	// 		setIterators();
-
-
-	// 		linbox_check(_size==0 || _ptr != NULL);
-	// 	}
-
-	// 	BlasVector (const _Field &F, const Integer & m, const Element e=Element())  :
-	// 		Father_t(),
-	// 		_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-	// 	{
-	// // Father_t is garbage until then:
-	// 		setIterators();
-
-
-	// 		linbox_check(_size==0 || _ptr != NULL);
-	// 	}
 
 		//! @bug be careful with copy constructor. We should ban them and provide copy.
 		BlasVector (const BlasVector<_Field,_blasRep> &V)  :
@@ -301,7 +214,7 @@ namespace LinBox { /* BlasVector */
 		}
 
 		//! @bug F is last for matrix
-		template<class VectorBase>
+		template<class VectorBase, typename std::enable_if<!std::is_arithmetic<VectorBase>::value, int>::type=0>
 		BlasVector (const _Field & F, const VectorBase & V)  :
 			Father_t(), // will be created afterwards...
 			_size(V.size()),_1stride(1),_rep(V.size(), F.zero),_ptr(_rep.data()),_field(&F)

--- a/linbox/vector/blas-vector.h
+++ b/linbox/vector/blas-vector.h
@@ -182,51 +182,51 @@ namespace LinBox { /* BlasVector */
 			// linbox_check(_ptr != NULL);
 		}
 
-#if 0
-		void init(const _Field & F, size_t n = 0)
-		{
-			_field = &F;
-			_size = n;
-			_1stride=1 ;
-			_rep.resize(n, F.zero);
-			_ptr = _rep.data();
-		}
-#endif
+// #if 0
+// 		void init(const _Field & F, size_t n = 0)
+// 		{
+// 			_field = &F;
+// 			_size = n;
+// 			_1stride=1 ;
+// 			_rep.resize(n, F.zero);
+// 			_ptr = _rep.data();
+// 		}
+// #endif
 
-#ifdef __GNUC__
-#ifndef __x86_64__
-#if (__GNUC__ == 4 && __GNUC_MINOR__ ==4 && __GNUC_PATCHLEVEL__==5)
-		BlasVector (const _Field &F, const long &m, const Element e=Element()) :
+// #ifdef __GNUC__
+// #ifndef __x86_64__
+// #if (__GNUC__ == 4 && __GNUC_MINOR__ ==4 && __GNUC_PATCHLEVEL__==5)
+// 		BlasVector (const _Field &F, const long &m, const Element e=Element()) :
+// 			Father_t(),
+// 			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
+// 		{
+// 			// Father_t is garbage until then:
+// 			setIterators();
+
+// 			linbox_check(_size==0 || _ptr != NULL);
+// 		}
+// #endif
+// #endif
+// #endif
+
+// #if defined(__APPLE__) || (defined(__s390__) && !defined(__s390x__))
+// 		BlasVector (const _Field &F, const unsigned long &m, const Element e=Element())  :
+// 			Father_t(),
+// 			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
+// 		{
+// 			// Father_t is garbage until then:
+// 			setIterators();
+
+// 			linbox_check(_size==0 || _ptr != NULL);
+
+// 			// linbox_check(_size >= this->begin()->_stride); PG -> do not understand
+// 		}
+
+// #endif
+
+		BlasVector (const _Field &F, const size_t &m, const Element e=Element())  :
 			Father_t(),
-			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-		{
-			// Father_t is garbage until then:
-			setIterators();
-
-			linbox_check(_size==0 || _ptr != NULL);
-		}
-#endif
-#endif
-#endif
-
-#if defined(__APPLE__) || (defined(__s390__) && !defined(__s390x__))
-		BlasVector (const _Field &F, const unsigned long &m, const Element e=Element())  :
-			Father_t(),
-			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-		{
-			// Father_t is garbage until then:
-			setIterators();
-
-			linbox_check(_size==0 || _ptr != NULL);
-
-			// linbox_check(_size >= this->begin()->_stride); PG -> do not understand
-		}
-
-#endif
-
-		BlasVector (const _Field &F, const uint64_t &m, const Element e=Element())  :
-			Father_t(),
-			_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
+			_size(m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
 		{
 			// Father_t is garbage until then:
 			setIterators();
@@ -234,54 +234,54 @@ namespace LinBox { /* BlasVector */
 		}
 
 
-		BlasVector (const _Field &F, const int64_t &m, const Element e=Element())  :
-			Father_t(),
-			_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
-		{
-	// Father_t is garbage until then:
-			setIterators();
+	// 	BlasVector (const _Field &F, const int64_t &m, const Element e=Element())  :
+	// 		Father_t(),
+	// 		_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
+	// 	{
+	// // Father_t is garbage until then:
+	// 		setIterators();
 
 
-			linbox_check(_size==0 || _ptr != NULL);
-		}
+	// 		linbox_check(_size==0 || _ptr != NULL);
+	// 	}
 
 
-		BlasVector (const _Field &F, const uint32_t &m, const Element e=Element())  :
-			Father_t(),
-			_size((size_t)m),
-			_1stride(1),
-			_rep((size_t)_size, e),
-			_ptr(_rep.data()),
-			_field(&F)
-		{
-	// Father_t is garbage until then:
-			setIterators();
+	// 	BlasVector (const _Field &F, const uint32_t &m, const Element e=Element())  :
+	// 		Father_t(),
+	// 		_size((size_t)m),
+	// 		_1stride(1),
+	// 		_rep((size_t)_size, e),
+	// 		_ptr(_rep.data()),
+	// 		_field(&F)
+	// 	{
+	// // Father_t is garbage until then:
+	// 		setIterators();
 
 
-			linbox_check(_size==0 || _ptr != NULL);
-		}
+	// 		linbox_check(_size==0 || _ptr != NULL);
+	// 	}
 
-		BlasVector (const _Field &F, const int32_t &m, const Element e=Element())  :
-			Father_t(),
-			_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
-		{
-	// Father_t is garbage until then:
-			setIterators();
-
-
-			linbox_check(_size==0 || _ptr != NULL);
-		}
-
-		BlasVector (const _Field &F, const Integer & m, const Element e=Element())  :
-			Father_t(),
-			_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
-		{
-	// Father_t is garbage until then:
-			setIterators();
+	// 	BlasVector (const _Field &F, const int32_t &m, const Element e=Element())  :
+	// 		Father_t(),
+	// 		_size((size_t)m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
+	// 	{
+	// // Father_t is garbage until then:
+	// 		setIterators();
 
 
-			linbox_check(_size==0 || _ptr != NULL);
-		}
+	// 		linbox_check(_size==0 || _ptr != NULL);
+	// 	}
+
+	// 	BlasVector (const _Field &F, const Integer & m, const Element e=Element())  :
+	// 		Father_t(),
+	// 		_size((uint32_t)m),_1stride(1),_rep(_size, e),_ptr(_rep.data()),_field(&F)
+	// 	{
+	// // Father_t is garbage until then:
+	// 		setIterators();
+
+
+	// 		linbox_check(_size==0 || _ptr != NULL);
+	// 	}
 
 		//! @bug be careful with copy constructor. We should ban them and provide copy.
 		BlasVector (const BlasVector<_Field,_blasRep> &V)  :

--- a/linbox/vector/blas-vector.h
+++ b/linbox/vector/blas-vector.h
@@ -189,7 +189,7 @@ namespace LinBox { /* BlasVector */
         template<class SizeType, typename std::enable_if<std::is_arithmetic<SizeType>::value, int>::type=0>
 		BlasVector (const _Field &F, const SizeType &m, const Element e=Element())  :
 			Father_t(),
-			_size(m),_1stride(1),_rep((size_t)_size, e),_ptr(_rep.data()),_field(&F)
+			_size(m),_1stride(1),_rep((size_t)m, e),_ptr(_rep.data()),_field(&F)
 		{
 			// Father_t is garbage until then:
 			setIterators();


### PR DESCRIPTION
pretty much everywhere.
Rationale: 
* size_t is the standard type for anything related to matrix/vector dimensions, rank, indices, and also thresholds, and so on.
* The change in the constructor of BlasVector is the only place where it was non-trivial, because of the type resolution problem on OSX reported in #138 . A solution would be to have just one constructor with a dimension (a size_t) but on OSX, if you call the constructor with a signed litteral (eg. v(F,3) ), the int would never be cast to a size_t and the templated constructor would be called, causing compilation error. Instead the second solution, implemented here, is to have 2 templated constructors, with a `is_arithmetic` test on the template argument.