### PR TITLE
Fix `cnull` init and commentator.* indentation.

### DIFF
--- a/linbox/util/commentator.h
+++ b/linbox/util/commentator.h
@@ -10,7 +10,7 @@
  * ========LICENCE========
  * This file is part of the library LinBox.
  *
-  * LinBox is free software: you can redistribute it and/or modify
+ * LinBox is free software: you can redistribute it and/or modify
  * it under the terms of the  GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
@@ -76,970 +76,970 @@
 
 namespace LinBox
 {
-	// Forward declaration
-	class MessageClass;
-	class Commentator;
+    // Forward declaration
+    class MessageClass;
+    class Commentator;
 
-	// \class ActivityState commentator.h linbox/util/commentator.h
-	/** @internal
-	 * \brief used by commentator
+    // \class ActivityState commentator.h linbox/util/commentator.h
+    /** @internal
+     * \brief used by commentator
 
-	 * This stores a snapshot of the state of the commentator's activity
-	 * stack, so it may be restored after an exception is thrown
-	 */
-	class ActivityState {
-	public:
+     * This stores a snapshot of the state of the commentator's activity
+     * stack, so it may be restored after an exception is thrown
+     */
+    class ActivityState {
+    public:
 
-		ActivityState (void *act) :
-			_act (act)
-		{}
+        ActivityState (void *act) :
+            _act (act)
+        {}
 
-	private:
+    private:
 
-		friend class Commentator;
+        friend class Commentator;
 
-		void *_act;
-	};
+        void *_act;
+    };
 
-	/** @brief Give information to user during runtime.
-	 * \ingroup util
-	 *
-	 * This object is used for reporting information about a computation to
-	 * the user. Such information includes errors and warnings, descriptions
-	 * of internal progress, performance measurements, and timing
-	 * estimates. It also includes facilities for controlling the type and
-	 * amount of information displayed.
-	 *
-	 * Typical usage follows the following pattern:
-	 \code
-	 void myFunction ()
-	 {
-	     commentator().start ("Doing important work", "myFunction", 100);
-	     for (int i = 0; i < 100; i++) {
-	         ...
-	         commentator().progress ();
-	     }
-	     commentator().stop (MSG_DONE, "Task completed successfully");
-	 }
-	 \endcode
-	 *
-	 * In the above example, the call to commentator().start () informs the
-	 * commentator that some new activity has begun. This may be invoked
-	 * recursively, an the commentator keeps track of nested activities. The
-	 * user may elect to disable the reporting of any activities below a
-	 * certain depth of nesting. The call to commentator().stop () informs the
-	 * commentator that the activity started above is finished.
-	 *
-	 * The call to commentator().progress () indicates that one step of the
-	 * activity is complete. The commentator may then output data to the
-	 * console to that effect. This allows the easy implementation of
-	 * progress bars and other reporting tools.
-	 *
-	 * In addition, commentator().report () allows reporting general messages,
-	 * such as warnings, errors, and descriptions of internal progress.
-	 *
-	 * By default, there are two reports: a brief report that outputs to
-	 * cout, and a detailed report that outputs to a file that is
-	 * specified. If no file is specified, the detailed report is thrown
-	 * out. The brief report is intended either for human consumption or to
-	 * be piped to some other process. Therefore, there are two output
-	 * formats for that report. One can further customize the report style
-	 * by inheriting the commentator object.
-	 *
-	 * The commentator allows very precise control over what gets
-	 * printed. See the Configuration section below.
-	 */
-	class Commentator {
-	public:
-		/** @internal
-		 * Default constructor.
-		 * Constructs a commentator with default settings
-		 */
-		Commentator ();
-		Commentator (std::ostream&);
-
-
-		/** @internal
-		 * Default destructor.
-		*/
-		virtual ~Commentator ();
-
-		/**@internal
-		 * @name Reporting facilities.
-		 * @{
-		*/
+    /** @brief Give information to user during runtime.
+     * \ingroup util
+     *
+     * This object is used for reporting information about a computation to
+     * the user. Such information includes errors and warnings, descriptions
+     * of internal progress, performance measurements, and timing
+     * estimates. It also includes facilities for controlling the type and
+     * amount of information displayed.
+     *
+     * Typical usage follows the following pattern:
+     \code
+     void myFunction ()
+     {
+     commentator().start ("Doing important work", "myFunction", 100);
+     for (int i = 0; i < 100; i++) {
+     ...
+     commentator().progress ();
+     }
+     commentator().stop (MSG_DONE, "Task completed successfully");
+     }
+     \endcode
+     *
+     * In the above example, the call to commentator().start () informs the
+     * commentator that some new activity has begun. This may be invoked
+     * recursively, an the commentator keeps track of nested activities. The
+     * user may elect to disable the reporting of any activities below a
+     * certain depth of nesting. The call to commentator().stop () informs the
+     * commentator that the activity started above is finished.
+     *
+     * The call to commentator().progress () indicates that one step of the
+     * activity is complete. The commentator may then output data to the
+     * console to that effect. This allows the easy implementation of
+     * progress bars and other reporting tools.
+     *
+     * In addition, commentator().report () allows reporting general messages,
+     * such as warnings, errors, and descriptions of internal progress.
+     *
+     * By default, there are two reports: a brief report that outputs to
+     * cout, and a detailed report that outputs to a file that is
+     * specified. If no file is specified, the detailed report is thrown
+     * out. The brief report is intended either for human consumption or to
+     * be piped to some other process. Therefore, there are two output
+     * formats for that report. One can further customize the report style
+     * by inheriting the commentator object.
+     *
+     * The commentator allows very precise control over what gets
+     * printed. See the Configuration section below.
+     */
+    class Commentator {
+    public:
+        /** @internal
+         * Default constructor.
+         * Constructs a commentator with default settings
+         */
+        Commentator ();
+        Commentator (std::ostream&);
 
 
-		/** <!--@internal-->
-		 * Start an activity.
-		 * Inform the commentator that some new activity has begun. This
-		 * is typically called at the beginning of a library function.
-		 * @param description A human-readable text description of the
-		 *                    activity
-		 * @param fn The fully-qualified name of the function. Use 0 to
-		 *           use the same function as the surrounding activity
-		 *           (default 0)
-		 * @param len Number of items involved in this activity. Used
-		 *            for progress reporting; use 0 if this is not
-		 *            applicable to the situation in question.
-		 *            (default 0)
-		 */
-		void start (const char *description,
-			    const char *fn = (const char *) 0,
-			    unsigned long len = 0);
-		void start (std::string description,
-			    const char *fn = (const char *) 0,
-			    unsigned long len = 0);
+        /** @internal
+         * Default destructor.
+         */
+        virtual ~Commentator ();
+
+        /**@internal
+         * @name Reporting facilities.
+         * @{
+         */
 
 
-		/** @internal
-		 * Start a new iteration.
-		 * This is a convenience function to indicate that an iteration
-		 * has started
-		 * @param iter Number of the iteration
-		 * @param len Number of items involved in this activity. Used
-		 *            for progress reporting; use 0 if this is not
-		 *            applicable to the situation in question.
-		 *            (default 0)
-		 */
-		void startIteration (unsigned int iter, unsigned long len = 0);
-
-		/** <!--@internal-->
-		 * Stop an activity.
-		 * Inform the commentator that the current activity has
-		 * finished.
-		 * @param msg A short (one word) message describing the
-		 *            termination, e.g. "passed", "FAILED", "ok", etc.
-		 * @param long_msg A longer message describing the nature of
-		 *                 the termination. May be 0, in which case msg
-		 *                 is used.
-		 * @param fn Name of the function whose activity is
-		 *           complete. This is intended for checking to make
-		 *           sure that each call to start () is matched with a
-		 *           call to stop (). It is optional, and has no other
-		 *           effect.
-		 */
-		void stop (const char *msg = MSG_DONE,
-			   const char *long_msg = (const char *) 0,
-			   const char *fn = (const char *) 0);
-
-		/** <!--@internal-->
-		 * Report progress in the current activity.
-		 * Inform the commentator that k steps of the current activity
-		 * have been completed.
-		 * @param k Number of steps completed; use -1 to increment the
-		 *          current counter
-		 * @param len Total length of the operation; use -1 to use the
-		 *            existing length. This allows updating of inexact
-		 *            estimates of the number of steps.
-		 */
-		void progress (long k = -1, long len = -1);
-
-		/** @internal
-		 * Message level.
-		 * Some default settings to use for the message level
-		 */
-		enum MessageLevel {
-			LEVEL_ALWAYS       =  0,
-			LEVEL_IMPORTANT    =  1,
-			LEVEL_NORMAL       =  2,
-			LEVEL_UNIMPORTANT  =  3
-		};
-
-		/** <!--@internal-->
-		 * Basic reporting.
-		 * Send some report string to the commentator
-		 * @param level Level of detail of the message
-		 * @param msg_class Type of message
-		 * @return A reference to the stream to which to output data
-		 */
-		std::ostream &report (long level = LEVEL_IMPORTANT, const char *msg_class = INTERNAL_DESCRIPTION);
-
-		/** @internal
-		 * Indent to the correct column on the given string.
-		*/
-		void indent (std::ostream &stream) const;
-
-		//@} Reporting facilities
+        /** <!--@internal-->
+         * Start an activity.
+         * Inform the commentator that some new activity has begun. This
+         * is typically called at the beginning of a library function.
+         * @param description A human-readable text description of the
+         *                    activity
+         * @param fn The fully-qualified name of the function. Use 0 to
+         *           use the same function as the surrounding activity
+         *           (default 0)
+         * @param len Number of items involved in this activity. Used
+         *            for progress reporting; use 0 if this is not
+         *            applicable to the situation in question.
+         *            (default 0)
+         */
+        void start (const char *description,
+                    const char *fn = (const char *) 0,
+                    unsigned long len = 0);
+        void start (std::string description,
+                    const char *fn = (const char *) 0,
+                    unsigned long len = 0);
 
 
-		/** @internal
-		 * @name Activity stack restoration.
-		 *
-		 * The methods below facilitate restoring the activity stack
-		 * after an exception has been thrown. If user code wishes to
-		 * catch an exception, it should invoke the method
-		 * saveActivityState before the try block, storing the result in
-		 * an ActivityState object. Then it may invoke
-		 * restoreActivityState, passing the ActivityState object, in
-		 * each of the catch blocks.
-		 */
+        /** @internal
+         * Start a new iteration.
+         * This is a convenience function to indicate that an iteration
+         * has started
+         * @param iter Number of the iteration
+         * @param len Number of items involved in this activity. Used
+         *            for progress reporting; use 0 if this is not
+         *            applicable to the situation in question.
+         *            (default 0)
+         */
+        void startIteration (unsigned int iter, unsigned long len = 0);
 
-		//@{
+        /** <!--@internal-->
+         * Stop an activity.
+         * Inform the commentator that the current activity has
+         * finished.
+         * @param msg A short (one word) message describing the
+         *            termination, e.g. "passed", "FAILED", "ok", etc.
+         * @param long_msg A longer message describing the nature of
+         *                 the termination. May be 0, in which case msg
+         *                 is used.
+         * @param fn Name of the function whose activity is
+         *           complete. This is intended for checking to make
+         *           sure that each call to start () is matched with a
+         *           call to stop (). It is optional, and has no other
+         *           effect.
+         */
+        void stop (const char *msg = MSG_DONE,
+                   const char *long_msg = (const char *) 0,
+                   const char *fn = (const char *) 0);
 
-		/** @internal
-		 * Save activity state.
-		 *
-		 * Saves a copy of the activity state and returns it to the
-		 * caller. The caller need only pass this object back to
-		 * \ref restoreActivityState to return the commentator's
-		 * activity stack to the state it was when saveActivityState was
-		 * called.
-		 *
-		 * @return ActivityState object
-		 */
+        /** <!--@internal-->
+         * Report progress in the current activity.
+         * Inform the commentator that k steps of the current activity
+         * have been completed.
+         * @param k Number of steps completed; use -1 to increment the
+         *          current counter
+         * @param len Total length of the operation; use -1 to use the
+         *            existing length. This allows updating of inexact
+         *            estimates of the number of steps.
+         */
+        void progress (long k = -1, long len = -1);
 
-		ActivityState saveActivityState () const
-		{
-		       	return ActivityState (_activities.top ());
-		}
+        /** @internal
+         * Message level.
+         * Some default settings to use for the message level
+         */
+        enum MessageLevel {
+            LEVEL_ALWAYS       =  0,
+            LEVEL_IMPORTANT    =  1,
+            LEVEL_NORMAL       =  2,
+            LEVEL_UNIMPORTANT  =  3
+        };
 
-		/** @internal
-		 * Restore activity state.
-		 *
-		 * Restores the activity state to the point it was when the
-		 * given ActivityState object was passed. Note that this
-		 * function assumes that the commentator is currently in a more
-		 * deeply-nested configuration than when the object was created;
-		 * if it is not, the method will give up.
-		 */
+        /** <!--@internal-->
+         * Basic reporting.
+         * Send some report string to the commentator
+         * @param level Level of detail of the message
+         * @param msg_class Type of message
+         * @return A reference to the stream to which to output data
+         */
+        std::ostream &report (long level = LEVEL_IMPORTANT, const char *msg_class = INTERNAL_DESCRIPTION);
 
-		void restoreActivityState (ActivityState state);
+        /** @internal
+         * Indent to the correct column on the given string.
+         */
+        void indent (std::ostream &stream) const;
 
-		/** @internal
-		 * @name Configuration
-		*/
+        //@} Reporting facilities
 
-		//@{
 
-		/** @internal
-		 * Output format.
-		 * OUTPUT_CONSOLE - output human-readable and tailor-made for the console
-		 * OUTPUT_PIPE - output made for piping into other processes
-		 *
-		 * This affects only the brief report
-		 */
-		enum OutputFormat {
-		       	OUTPUT_CONSOLE,
-		       	OUTPUT_PIPE
-		};
+        /** @internal
+         * @name Activity stack restoration.
+         *
+         * The methods below facilitate restoring the activity stack
+         * after an exception has been thrown. If user code wishes to
+         * catch an exception, it should invoke the method
+         * saveActivityState before the try block, storing the result in
+         * an ActivityState object. Then it may invoke
+         * restoreActivityState, passing the ActivityState object, in
+         * each of the catch blocks.
+         */
 
-		enum EstimationMethod {
-			BEST_ESTIMATE,
-			POLY_ESTIMATE,
-			EXPO_ESTIMATE
-		};
+        //@{
 
-		enum TimingDelay {
-			SHORT_TIMING,
-			LONG_TIMING
-		};
+        /** @internal
+         * Save activity state.
+         *
+         * Saves a copy of the activity state and returns it to the
+         * caller. The caller need only pass this object back to
+         * \ref restoreActivityState to return the commentator's
+         * activity stack to the state it was when saveActivityState was
+         * called.
+         *
+         * @return ActivityState object
+         */
 
-		/** @internal
-		 * Set maximum message depth.
-		 * Sets the maximum activity depth, as defined by
-		 * \c Commentator::start and \c Commentator::stop, at which messages
-		 * of all classes will be printed.
-		 * @param depth Maximum depth at which to print messages; set to
-		 *              -1 to print messages at any depth and 0 to
-		 *              disable entirely
-		 */
-		void setMaxDepth (long depth);
+        ActivityState saveActivityState () const
+        {
+            return ActivityState (_activities.top ());
+        }
 
-		/** @internal
-		 * Set maximum detail level.
-		 * Sets the maximum detail level at which to print messages
-		 * @param level Maximum detail level at which to print messages;
-		 *              set to -1 to print messages at all levels and 0
-		 *              to disable entirely
-		 */
-		void setMaxDetailLevel (long level);
+        /** @internal
+         * Restore activity state.
+         *
+         * Restores the activity state to the point it was when the
+         * given ActivityState object was passed. Note that this
+         * function assumes that the commentator is currently in a more
+         * deeply-nested configuration than when the object was created;
+         * if it is not, the method will give up.
+         */
 
-		/** @internal
-		 * Register a new message class.
-		 * Register some new message class with the commentator.
-		 * @param msg_class Name of message class
-		 * @param stream Stream to which to send data of this type
-		 * @param max_depth Default maximum recursion depth at which to
-		 *                  print messages of this class (default 1)
-		 * @param max_level Default maximum detail level at which to
-		 *                  print messages of this class (default 2, or
-		 *                  LEVEL_IMPORTANT)
-		 * @return A reference to the new message class object
-		 */
-		MessageClass &registerMessageClass (const char *msg_class,
-						    std::ostream &stream,
-						    unsigned long max_depth = 1,
-						    unsigned long max_level = 2);
+        void restoreActivityState (ActivityState state);
 
-		/** @internal
-		 * Clone an existing message class.
-		 * Clone the message class to construct a new message class with
-		 * the same parameters.
-		 * @param new_msg_class Name of the new class
-		 * @param msg_class Name of class to clone
-		 * @return A reference to the new message class object
-		 */
-		MessageClass &cloneMessageClass (const char *new_msg_class, const char *msg_class);
+        /** @internal
+         * @name Configuration
+         */
 
-		/** @internal
-		 * Clone an existing message class, specifying a new output stream.
-		 * Clone the message class to construct a new message class with
-		 * the same parameters.
-		 * @param new_msg_class Name of the new class
-		 * @param msg_class Name of class to clone
-		 * @param stream New stream to which to direct output
-		 * @return A reference to the new message class object
-		 */
-		MessageClass &cloneMessageClass (const char *new_msg_class,
-						 const char *msg_class,
-						 std::ostream &stream);
+        //@{
 
-		/** @internal
-		 * Retrieve a message class by name.
-		 * @param msg_class Name of message class
-		 * @return Reference to message class object
-		 */
-		MessageClass &getMessageClass (const char *msg_class);
+        /** @internal
+         * Output format.
+         * OUTPUT_CONSOLE - output human-readable and tailor-made for the console
+         * OUTPUT_PIPE - output made for piping into other processes
+         *
+         * This affects only the brief report
+         */
+        enum OutputFormat {
+            OUTPUT_CONSOLE,
+            OUTPUT_PIPE
+        };
 
-		/** @internal
-		 * Precise control over printing.
-		 * Specifies that all messages up to the given depth and the
-		 * given detail level should be printed
-		 *
-		 * This is similar to MessageClass::setPrintParameters but
-		 * affects all message classes simultaneously.
-		 * @param depth Depth up to which directive is valid
-		 * @param level Detail level up to which directive is valid
-		 * @param fn Fully qualified name of the function for which this
-		 *           is valid; may be 0, in which case this is valid for
-		 *           everything
-		 */
-		void setPrintParameters (unsigned long depth,
-					 unsigned long level,
-					 const char *fn = (const char *) 0);
+        enum EstimationMethod {
+            BEST_ESTIMATE,
+            POLY_ESTIMATE,
+            EXPO_ESTIMATE
+        };
 
-		/** @internal
-		 * Set parameters for the brief report.
-		 * @param format Output format
-		 * @param show_timing Show the CPU time for each toplevel activity
-		 * @param show_progress Show a counter of the progress as each
-		 *                      activity progresses
-		 * @param show_est_time Show estimated time remaining
-		 */
-		void setBriefReportParameters (OutputFormat format,
-					       bool show_timing,
-					       bool show_progress,
-					       bool show_est_time);
+        enum TimingDelay {
+            SHORT_TIMING,
+            LONG_TIMING
+        };
 
-		/** @internal
-		 * Determine whether a message will be printed.
-		 * @param depth Activity depth
-		 * @param level Message level
-		 * @param msg_class Type of message
-		 * @param fn Fully qualified function name (0 if not applicable)
-		 * @return true if the message with the given characteristics
-		 *         will be printed as things are currently configured
-		 */
-		bool isPrinted (unsigned long depth,
-				unsigned long level,
-				const char *msg_class,
-				const char *fn = (const char *) 0);
+        /** @internal
+         * Set maximum message depth.
+         * Sets the maximum activity depth, as defined by
+         * \c Commentator::start and \c Commentator::stop, at which messages
+         * of all classes will be printed.
+         * @param depth Maximum depth at which to print messages; set to
+         *              -1 to print messages at any depth and 0 to
+         *              disable entirely
+         */
+        void setMaxDepth (long depth);
 
-		/** @internal
-		 * Determine whether a message will be printed.
-		 * This variant uses the current activity depth rather than
-		 * specifying it explicitly.
-		 * @param level Message level
-		 * @param msg_class Type of message
-		 * @param fn Fully qualified function name (0 if not applicable)
-		 * @return true if the message with the given characteristics
-		 *         will be printed as things are currently configured
-		 */
-		bool isPrinted (unsigned long level,
-				const char *msg_class,
-				const char *fn = (const char *) 0)
-		{
-		       	return isPrinted (_activities.size (), level, msg_class, fn);
-		}
+        /** @internal
+         * Set maximum detail level.
+         * Sets the maximum detail level at which to print messages
+         * @param level Maximum detail level at which to print messages;
+         *              set to -1 to print messages at all levels and 0
+         *              to disable entirely
+         */
+        void setMaxDetailLevel (long level);
 
-		/** @internal
-		 * Determine whether the stream given is the null stream.
-		 * @param str Stream to check
-		 * @return true if stream is the null stream; false otherwise
-		 */
-		bool isNullStream (const std::ostream &str)
-		{
-			return &str == &cnull;
-		}
+        /** @internal
+         * Register a new message class.
+         * Register some new message class with the commentator.
+         * @param msg_class Name of message class
+         * @param stream Stream to which to send data of this type
+         * @param max_depth Default maximum recursion depth at which to
+         *                  print messages of this class (default 1)
+         * @param max_level Default maximum detail level at which to
+         *                  print messages of this class (default 2, or
+         *                  LEVEL_IMPORTANT)
+         * @return A reference to the new message class object
+         */
+        MessageClass &registerMessageClass (const char *msg_class,
+                                            std::ostream &stream,
+                                            unsigned long max_depth = 1,
+                                            unsigned long max_level = 2);
 
-		/** @internal
-		 * Set output stream for brief report.
-		 * @param stream Output stream
-		 */
-		void setBriefReportStream (std::ostream &stream);
+        /** @internal
+         * Clone an existing message class.
+         * Clone the message class to construct a new message class with
+         * the same parameters.
+         * @param new_msg_class Name of the new class
+         * @param msg_class Name of class to clone
+         * @return A reference to the new message class object
+         */
+        MessageClass &cloneMessageClass (const char *new_msg_class, const char *msg_class);
 
-		/** @internal
-		 * Set output stream for all reports other than the brief.
-		 * report
-		 * @param stream Output stream
-		 */
-		void setReportStream (std::ostream &stream);
+        /** @internal
+         * Clone an existing message class, specifying a new output stream.
+         * Clone the message class to construct a new message class with
+         * the same parameters.
+         * @param new_msg_class Name of the new class
+         * @param msg_class Name of class to clone
+         * @param stream New stream to which to direct output
+         * @return A reference to the new message class object
+         */
+        MessageClass &cloneMessageClass (const char *new_msg_class,
+                                         const char *msg_class,
+                                         std::ostream &stream);
 
-		/** @internal
-		 * Set the output stream for a given message class.
-		 * @param msg_class Message class
-		 * @param stream Output stream
-		 */
-		void setMessageClassStream (const char *msg_class, std::ostream &stream);
+        /** @internal
+         * Retrieve a message class by name.
+         * @param msg_class Name of message class
+         * @return Reference to message class object
+         */
+        MessageClass &getMessageClass (const char *msg_class);
 
-		/** @internal
-		 * Set default report file.
-		 * @param filename of file
-		 */
-		void setDefaultReportFile (const char *filename);
+        /** @internal
+         * Precise control over printing.
+         * Specifies that all messages up to the given depth and the
+         * given detail level should be printed
+         *
+         * This is similar to MessageClass::setPrintParameters but
+         * affects all message classes simultaneously.
+         * @param depth Depth up to which directive is valid
+         * @param level Detail level up to which directive is valid
+         * @param fn Fully qualified name of the function for which this
+         *           is valid; may be 0, in which case this is valid for
+         *           everything
+         */
+        void setPrintParameters (unsigned long depth,
+                                 unsigned long level,
+                                 const char *fn = (const char *) 0);
 
-		//@} Configuration
+        /** @internal
+         * Set parameters for the brief report.
+         * @param format Output format
+         * @param show_timing Show the CPU time for each toplevel activity
+         * @param show_progress Show a counter of the progress as each
+         *                      activity progresses
+         * @param show_est_time Show estimated time remaining
+         */
+        void setBriefReportParameters (OutputFormat format,
+                                       bool show_timing,
+                                       bool show_progress,
+                                       bool show_est_time);
 
-		/** @internal
-		 * @name Legacy commentator interface
-		 * These routines provide compatibility with the old commentator
-		 * interface. They are deprecated.
-		 * @deprecated
-		 */
+        /** @internal
+         * Determine whether a message will be printed.
+         * @param depth Activity depth
+         * @param level Message level
+         * @param msg_class Type of message
+         * @param fn Fully qualified function name (0 if not applicable)
+         * @return true if the message with the given characteristics
+         *         will be printed as things are currently configured
+         */
+        bool isPrinted (unsigned long depth,
+                        unsigned long level,
+                        const char *msg_class,
+                        const char *fn = (const char *) 0);
 
-		//@{
+        /** @internal
+         * Determine whether a message will be printed.
+         * This variant uses the current activity depth rather than
+         * specifying it explicitly.
+         * @param level Message level
+         * @param msg_class Type of message
+         * @param fn Fully qualified function name (0 if not applicable)
+         * @return true if the message with the given characteristics
+         *         will be printed as things are currently configured
+         */
+        bool isPrinted (unsigned long level,
+                        const char *msg_class,
+                        const char *fn = (const char *) 0)
+        {
+            return isPrinted (_activities.size (), level, msg_class, fn);
+        }
 
-		/** @internal
-		 * Start an activity.
-		 * @param id String identifier of activity
-		 * @param msg Message to print
-		 * @param msglevel Level of message
-		 * @param msgclass Class of message
-		 */
-		void start (const char *id, const char *msg, long msglevel, const char *msgclass)
-		{
-			start (id);
-			report ((MessageLevel) msglevel, msgclass) << msg << std::endl;
-		}
+        /** @internal
+         * Determine whether the stream given is the null stream.
+         * @param str Stream to check
+         * @return true if stream is the null stream; false otherwise
+         */
+        bool isNullStream (const std::ostream &str)
+        {
+            return &str == &cnull;
+        }
 
-		void start (std::string id, const char *msg, long msglevel, const char *msgclass)
-		{
-			start(id.c_str(),msg,msglevel,msgclass);
-		}
+        /** @internal
+         * Set output stream for brief report.
+         * @param stream Output stream
+         */
+        void setBriefReportStream (std::ostream &stream);
 
-		/** @internal
-		 * Stop an activity.
-		 * @param msg Message to print
-		 */
-		 /* @param msglevel Level of message
-		 * @param msgclass Class of message
-		 * @param time_type Type of timing to use
-		 */
-		void stop (const char *msg
-			   , long //msglevel
-			   , const char * //msgclass
-			   , long //time_type
-			  )
-		{
-			stop (msg);
-		}
+        /** @internal
+         * Set output stream for all reports other than the brief.
+         * report
+         * @param stream Output stream
+         */
+        void setReportStream (std::ostream &stream);
 
-		/** @internal
-		 * Report progress.
-		 * @param msg Message to print
-		 * @param msglevel Level of message
-		 * @param k Number of steps completed
-		 * @param n Total number of steps in operation
-		 */
-		void progress (const char *msg, long msglevel, long k, long n)
-		{
-			progress (k, n);
-			report ((MessageLevel) msglevel, INTERNAL_DESCRIPTION) << msg << std::endl;
-		}
+        /** @internal
+         * Set the output stream for a given message class.
+         * @param msg_class Message class
+         * @param stream Output stream
+         */
+        void setMessageClassStream (const char *msg_class, std::ostream &stream);
 
-		/** @internal
-		 * General reporting.
-		 * @param msg Message to print
-		 * @param msglevel Level of message
-		 * @param msgclass Class of message
-		 */
-		void report (const char *msg, long msglevel, const char *msgclass)
-		{
-			report ((MessageLevel) msglevel, msgclass) << msg << std::endl;
-		}
+        /** @internal
+         * Set default report file.
+         * @param filename of file
+         */
+        void setDefaultReportFile (const char *filename);
 
-		/** @internal
-		 * Test whether message is printed.
-		 * @param msglevel Level of message
-		 * @param msgclass Class of message
-		 */
-		bool printed (long msglevel, const char *msgclass)
-		{
-			return isPrinted (_activities.size (), (MessageLevel) msglevel, msgclass);
-		}
+        //@} Configuration
 
-		//@} Legacy commentator interface
+        /** @internal
+         * @name Legacy commentator interface
+         * These routines provide compatibility with the old commentator
+         * interface. They are deprecated.
+         * @deprecated
+         */
 
-		/** @internal
-		 * Use this stream to disable a message class entirely.
-		*/
-		std::ofstream cnull;
+        //@{
 
-	private:
+        /** @internal
+         * Start an activity.
+         * @param id String identifier of activity
+         * @param msg Message to print
+         * @param msglevel Level of message
+         * @param msgclass Class of message
+         */
+        void start (const char *id, const char *msg, long msglevel, const char *msgclass)
+        {
+            start (id);
+            report ((MessageLevel) msglevel, msgclass) << msg << std::endl;
+        }
+
+        void start (std::string id, const char *msg, long msglevel, const char *msgclass)
+        {
+            start(id.c_str(),msg,msglevel,msgclass);
+        }
+
+        /** @internal
+         * Stop an activity.
+         * @param msg Message to print
+         */
+        /* @param msglevel Level of message
+         * @param msgclass Class of message
+         * @param time_type Type of timing to use
+         */
+        void stop (const char *msg
+                   , long //msglevel
+                   , const char * //msgclass
+                   , long //time_type
+                  )
+        {
+            stop (msg);
+        }
+
+        /** @internal
+         * Report progress.
+         * @param msg Message to print
+         * @param msglevel Level of message
+         * @param k Number of steps completed
+         * @param n Total number of steps in operation
+         */
+        void progress (const char *msg, long msglevel, long k, long n)
+        {
+            progress (k, n);
+            report ((MessageLevel) msglevel, INTERNAL_DESCRIPTION) << msg << std::endl;
+        }
+
+        /** @internal
+         * General reporting.
+         * @param msg Message to print
+         * @param msglevel Level of message
+         * @param msgclass Class of message
+         */
+        void report (const char *msg, long msglevel, const char *msgclass)
+        {
+            report ((MessageLevel) msglevel, msgclass) << msg << std::endl;
+        }
+
+        /** @internal
+         * Test whether message is printed.
+         * @param msglevel Level of message
+         * @param msgclass Class of message
+         */
+        bool printed (long msglevel, const char *msgclass)
+        {
+            return isPrinted (_activities.size (), (MessageLevel) msglevel, msgclass);
+        }
+
+        //@} Legacy commentator interface
+
+        /** @internal
+         * Use this stream to disable a message class entirely.
+         */
+        std::ofstream cnull;
+
+    private:
 #if 0
-		// Null std::ostream prints nothing
-		struct nullstreambuf : public std::streambuf {
-			nullstreambuf() {};
-			// GV modidied seek_dir twice
-			std::streampos seekoff(std::streambuf::off_type, std::ios::seekdir, std::ios::openmode)
-			{
-				return 0;
-			}
-			std::streampos seekpos(std::streambuf::pos_type, std::ios::openmode)
-			{
-				return 0;
-			}
-			std::streampos sys_seek(std::streambuf::off_type, std::ios::seekdir)
-			{
-				return 0;
-			}
-			std::streamsize showmanyc ()
-			{
-				return 0;
-			}
-			void imbue(const std::locale &loc)
-			{}
-		};
+        // Null std::ostream prints nothing
+        struct nullstreambuf : public std::streambuf {
+            nullstreambuf() {};
+            // GV modidied seek_dir twice
+            std::streampos seekoff(std::streambuf::off_type, std::ios::seekdir, std::ios::openmode)
+            {
+                return 0;
+            }
+            std::streampos seekpos(std::streambuf::pos_type, std::ios::openmode)
+            {
+                return 0;
+            }
+            std::streampos sys_seek(std::streambuf::off_type, std::ios::seekdir)
+            {
+                return 0;
+            }
+            std::streamsize showmanyc ()
+            {
+                return 0;
+            }
+            void imbue(const std::locale &loc)
+            {}
+        };
 #endif
 
-	protected:
-		struct StepsAndTime {
-			StepsAndTime (long k = 0, double t = 0.0) :
-				_time(t), _steps(k)
-			{}
+    protected:
+        struct StepsAndTime {
+            StepsAndTime (long k = 0, double t = 0.0) :
+                _time(t), _steps(k)
+            {}
 
-			double                   _time;
-			long                     _steps;
-		};
+            double                   _time;
+            long                     _steps;
+        };
 
-		typedef std::deque<StepsAndTime> Estimator;
+        typedef std::deque<StepsAndTime> Estimator;
 
-		struct Activity {
-			Activity (const char *desc, const char *fn, unsigned long len) :
-				_desc (desc), _fn (fn), _len (len), _progress (0)
-			{}
+        struct Activity {
+            Activity (const char *desc, const char *fn, unsigned long len) :
+                _desc (desc), _fn (fn), _len (len), _progress (0)
+            {}
 
-			const char              *_desc;
-			const char              *_fn;
-			unsigned long            _len;
-			unsigned long            _progress;
-		 Givaro::RealTimer                    _timer;
-			Estimator                _estimate;
-		};
+            const char              *_desc;
+            const char              *_fn;
+            unsigned long            _len;
+            unsigned long            _progress;
+            Givaro::RealTimer                    _timer;
+            Estimator                _estimate;
+        };
 
-		std::stack<Activity *>           _activities;      // Stack of activity structures
+        std::stack<Activity *>           _activities;      // Stack of activity structures
 
-		struct C_str_Less {
-			bool operator() (const char* x, const char * y) const {
-				return strcmp(x,y)<0;
-			}
-		};
+        struct C_str_Less {
+            bool operator() (const char* x, const char * y) const {
+                return strcmp(x,y)<0;
+            }
+        };
 
-		std::map<const char *, MessageClass *, C_str_Less>
-		_messageClasses;
-		EstimationMethod                 _estimationMethod;     // Activity estimator
+        std::map<const char *, MessageClass *, C_str_Less>
+        _messageClasses;
+        EstimationMethod                 _estimationMethod;     // Activity estimator
 
-		// Brief report parameters
-		OutputFormat                     _format;
-		bool                             _show_timing;
-		bool                             _show_progress;
-		bool                             _show_est_time;
+        // Brief report parameters
+        OutputFormat                     _format;
+        bool                             _show_timing;
+        bool                             _show_progress;
+        bool                             _show_est_time;
 
-		unsigned int                     _last_line_len;      // Length of last printed line in the brief report
+        unsigned int                     _last_line_len;      // Length of last printed line in the brief report
 
-		std::ofstream                    _report;
+        std::ofstream                    _report;
 
-		std::string                      _iteration_str;     // String referring to current iteration -- HACK
+        std::string                      _iteration_str;     // String referring to current iteration -- HACK
 
-		// Functions for the brief report
-		virtual void printActivityReport  (Activity &activity);
-		virtual void updateActivityReport (Activity &activity);
-		virtual void finishActivityReport (Activity &activity, const char *msg);
-	};
+        // Functions for the brief report
+        virtual void printActivityReport  (Activity &activity);
+        virtual void updateActivityReport (Activity &activity);
+        virtual void finishActivityReport (Activity &activity, const char *msg);
+    };
 
-	/** @internal
-	 * Message class object.
-	 * This object encapsulates the configuration of a given message class
-	 */
-	class MessageClass {
-	public:
-		friend class Commentator;
+    /** @internal
+     * Message class object.
+     * This object encapsulates the configuration of a given message class
+     */
+    class MessageClass {
+    public:
+        friend class Commentator;
 
-		/**  @internal
-		 * Constructor.
-		 *
-		 * Constructs a new MessageClass object with the given type,
-		 * outputing to the given stream. All other parameters are set
-		 * to factory defaults.
-		 * @param comm Commentator for this message class
-		 * @param msg_class Name of message class
-		 * @param stream Output stream to which to send messages of this
-		 *               class
-		 * @param max_depth Default maximal recursion depth at which to
-		 *                  print messages of this class (default 2)
-		 * @param max_level Default maximal detail level at which to
-		 *                  print messages of this class (default 1)
-		 */
-		MessageClass (const Commentator &comm,
-			      const char *msg_class,
-			      std::ostream &stream,
-			      unsigned long max_depth = 1,
-			      unsigned long max_level = 2);
+        /**  @internal
+         * Constructor.
+         *
+         * Constructs a new MessageClass object with the given type,
+         * outputing to the given stream. All other parameters are set
+         * to factory defaults.
+         * @param comm Commentator for this message class
+         * @param msg_class Name of message class
+         * @param stream Output stream to which to send messages of this
+         *               class
+         * @param max_depth Default maximal recursion depth at which to
+         *                  print messages of this class (default 2)
+         * @param max_level Default maximal detail level at which to
+         *                  print messages of this class (default 1)
+         */
+        MessageClass (const Commentator &comm,
+                      const char *msg_class,
+                      std::ostream &stream,
+                      unsigned long max_depth = 1,
+                      unsigned long max_level = 2);
 
-		/** @internal
-		 * Copy constructor.
-		*/
-		MessageClass (const MessageClass &message_class) :
-			_msg_class (message_class._msg_class),
-			_smart_streambuf (message_class._smart_streambuf.comm (),
-					  message_class._smart_streambuf.stream ()),
-			_stream (&_smart_streambuf),
-			_configuration (message_class._configuration),
-			_max_level (message_class._max_level),
-			_max_depth (message_class._max_depth)
-		{}
+        /** @internal
+         * Copy constructor.
+         */
+        MessageClass (const MessageClass &message_class) :
+            _msg_class (message_class._msg_class),
+            _smart_streambuf (message_class._smart_streambuf.comm (),
+                              message_class._smart_streambuf.stream ()),
+            _stream (&_smart_streambuf),
+            _configuration (message_class._configuration),
+            _max_level (message_class._max_level),
+            _max_depth (message_class._max_depth)
+        {}
 
-		/** @internal
-		 * Set maximum message depth.
-		 * Sets the maximum activity depth, as defined by
-		 * Commentator::start and Commentator::stop, at which messages
-		 * of this class will be printed.
-		 * @param depth Maximum depth at which to print messages; set to
-		 *              -1 to print messages at any depth and 0 to
-		 *              disable entirely
-		 */
-		void setMaxDepth (long depth);
+        /** @internal
+         * Set maximum message depth.
+         * Sets the maximum activity depth, as defined by
+         * Commentator::start and Commentator::stop, at which messages
+         * of this class will be printed.
+         * @param depth Maximum depth at which to print messages; set to
+         *              -1 to print messages at any depth and 0 to
+         *              disable entirely
+         */
+        void setMaxDepth (long depth);
 
-		/** @internal
-		 * Set maximum detail level.
-		 * Sets the maximum detail level at which to print messages
-		 * @param level Maximum detail level at which to print messages;
-		 *              set to -1 to print messages at all levels and 0
-		 *              to disable entirely
-		 */
-		void setMaxDetailLevel (long level);
+        /** @internal
+         * Set maximum detail level.
+         * Sets the maximum detail level at which to print messages
+         * @param level Maximum detail level at which to print messages;
+         *              set to -1 to print messages at all levels and 0
+         *              to disable entirely
+         */
+        void setMaxDetailLevel (long level);
 
-		/** @internal
-		 * Precise control over printing.
-		 * Specifies that all messages up to the given depth and the
-		 * given activity level should be printed
-		 * @param depth Maximum depth at which to print
-		 * @param level Maximum detail level at which to print
-		 * @param fn Fully qualified name of the function for which this
-		 *           is valid; may be 0, in which case this is valid for
-		 *           everything
-		 */
-		void setPrintParameters (unsigned long depth, unsigned long level, const char *fn);
+        /** @internal
+         * Precise control over printing.
+         * Specifies that all messages up to the given depth and the
+         * given activity level should be printed
+         * @param depth Maximum depth at which to print
+         * @param level Maximum detail level at which to print
+         * @param fn Fully qualified name of the function for which this
+         *           is valid; may be 0, in which case this is valid for
+         *           everything
+         */
+        void setPrintParameters (unsigned long depth, unsigned long level, const char *fn);
 
-		/** @internal
-		 * Determine whether a given message will be printed when of
-		 * this message class.
-		 * @param depth Activity depty of the message
-		 * @param level Detail level of the message
-		 * @param fn Fully qualified function name (0 if not applicable;
-		 *           default 0)
-		 * @return true if a message of the given characteristics is
-		 *         printed
-		 */
-		bool isPrinted (unsigned long depth, unsigned long level, const char *fn = (const char *) 0);
+        /** @internal
+         * Determine whether a given message will be printed when of
+         * this message class.
+         * @param depth Activity depty of the message
+         * @param level Detail level of the message
+         * @param fn Fully qualified function name (0 if not applicable;
+         *           default 0)
+         * @return true if a message of the given characteristics is
+         *         printed
+         */
+        bool isPrinted (unsigned long depth, unsigned long level, const char *fn = (const char *) 0);
 
-	private:
-		typedef std::map <const char *, std::list<std::pair <unsigned long, unsigned long> > > Configuration;
+    private:
+        typedef std::map <const char *, std::list<std::pair <unsigned long, unsigned long> > > Configuration;
 
-		class smartStreambuf : public std::streambuf {
-			const Commentator &_comm;
-			std::ostream &_stream;
-			bool _indent_next;
+        class smartStreambuf : public std::streambuf {
+            const Commentator &_comm;
+            std::ostream &_stream;
+            bool _indent_next;
 
-		public:
-			smartStreambuf (const Commentator &Comm, std::ostream & Stream) :
-				_comm (Comm), _stream (Stream), _indent_next (true)
-			{}
+        public:
+            smartStreambuf (const Commentator &Comm, std::ostream & Stream) :
+                _comm (Comm), _stream (Stream), _indent_next (true)
+            {}
 
-			int sync ();
-			int overflow (int ch);
-			std::streamsize xsputn (const char *text, std::streamsize n);
-			int writeData (const char *text, std::streamsize n);
+            int sync ();
+            int overflow (int ch);
+            std::streamsize xsputn (const char *text, std::streamsize n);
+            int writeData (const char *text, std::streamsize n);
 
-			const Commentator &comm () const
-			{
-			       	return _comm;
-			}
-			std::ostream &stream () const
-			{
-			       	return _stream;
-			}
-		};
+            const Commentator &comm () const
+            {
+                return _comm;
+            }
+            std::ostream &stream () const
+            {
+                return _stream;
+            }
+        };
 
-		const char     *_msg_class; // Name of this message class
-		smartStreambuf  _smart_streambuf;
-		std::ostream    _stream;    // Stream to which to output data
+        const char     *_msg_class; // Name of this message class
+        smartStreambuf  _smart_streambuf;
+        std::ostream    _stream;    // Stream to which to output data
 
-		Configuration   _configuration;
+        Configuration   _configuration;
 
-		unsigned long   _max_level;
-		unsigned long   _max_depth;
+        unsigned long   _max_level;
+        unsigned long   _max_depth;
 
-		// Constructor that gives existing configuration to copy
-		MessageClass (const Commentator &comm, const char *msg_class, std::ostream &stream, Configuration configuration);
+        // Constructor that gives existing configuration to copy
+        MessageClass (const Commentator &comm, const char *msg_class, std::ostream &stream, Configuration configuration);
 
-		void fixDefaultConfig ();
-		bool checkConfig (std::list <std::pair <unsigned long, unsigned long> > &config, unsigned long depth, unsigned long level);
-		void dumpConfig () const;   // Dump the contents of configuration to stderr
-	};
+        void fixDefaultConfig ();
+        bool checkConfig (std::list <std::pair <unsigned long, unsigned long> > &config, unsigned long depth, unsigned long level);
+        void dumpConfig () const;   // Dump the contents of configuration to stderr
+    };
 
-	// Default static commentator is now common to enabled or disabled
-// 	extern Commentator commentator;
-}
+    // Default static commentator is now common to enabled or disabled
+    // 	extern Commentator commentator;
+    }
 
-// #ifdef LinBoxSrcOnly
-// #include "linbox/util/commentator.C"
-// #endif
+    // #ifdef LinBoxSrcOnly
+    // #include "linbox/util/commentator.C"
+    // #endif
 #include "linbox/util/commentator.inl"
 
 #define aside commentator().report(Commentator::LEVEL_IMPORTANT, INTERNAL_DESCRIPTON)
-// Usage: "aside << stuff" or "ostream& report = aside; report << stuff"
+    // Usage: "aside << stuff" or "ostream& report = aside; report << stuff"
 
 #else //DISABLE_COMMENTATOR
 
 #define aside NoStream()
-struct NoStream {};
-template<typename T>
-NoStream & operator<< (NoStream& o, const T & x) { return o; }
+    struct NoStream {};
+    template<typename T>
+    NoStream & operator<< (NoStream& o, const T & x) { return o; }
 #if 0
 #  define Commentator CommentatorDisabled
 #  define MessageClass MessageClassDisabled
 #  define commentator commentatorDisabled
 #endif
 
-// This provides a "null" commentator that should compile totally out of the
-// program when DISABLE_COMMENTATOR is defined. All code making use of the
-// commentator should disappear.
+    // This provides a "null" commentator that should compile totally out of the
+    // program when DISABLE_COMMENTATOR is defined. All code making use of the
+    // commentator should disappear.
 
 
-namespace LinBox
-{
-	// Forward declaration
-	class Commentator;
+    namespace LinBox
+    {
+        // Forward declaration
+        class Commentator;
 
-	class MessageClass {
-	public:
-		friend class Commentator;
+        class MessageClass {
+        public:
+            friend class Commentator;
 
-		inline MessageClass (const char *, std::ostream &, unsigned long = 1, unsigned long = 2)
-	       	{}
-		inline MessageClass ()
-	       	{}
-		inline void setMaxDepth (long )
-	       	{}
-		inline void setMaxDetailLevel (long )
-	       	{}
-		inline void setPrintParameters (unsigned long, unsigned long , const char *)
-	       	{}
-		inline bool isPrinted (unsigned long , unsigned long , const char * = (const char *) 0)
-		{ return false; }
-	};
+            inline MessageClass (const char *, std::ostream &, unsigned long = 1, unsigned long = 2)
+            {}
+            inline MessageClass ()
+            {}
+            inline void setMaxDepth (long )
+            {}
+            inline void setMaxDetailLevel (long )
+            {}
+            inline void setPrintParameters (unsigned long, unsigned long , const char *)
+            {}
+            inline bool isPrinted (unsigned long , unsigned long , const char * = (const char *) 0)
+            { return false; }
+        };
 
-	class ActivityState {};
+        class ActivityState {};
 
-	class Commentator {
-	public:
+        class Commentator {
+        public:
 #if 0
-		inline Commentator () :
-			cnull (new nullstreambuf)
-		{}
-		inline Commentator () :
-			cnull ("/dev/null")
-		{}
+            inline Commentator () :
+                cnull (new nullstreambuf)
+            {}
+            inline Commentator () :
+                cnull ("/dev/null")
+            {}
 #endif
-		inline Commentator (std::ostream& out = std::cerr) :
-            cnull ("/dev/null")
-		{}
-		inline  ~Commentator ()
-	       	{}
-		inline void start (const char *, const char * = (const char *) 0, unsigned long = 0)
-	       	{}
-		inline void startIteration (unsigned int , unsigned long = 0)
-		{}
-		inline void stop (const char *, const char * = (const char *) 0, const char * = (const char *) 0)
-		{}
-		inline void progress (long = -1, long = -1)
-	       	{}
+            inline Commentator (std::ostream& out = std::cerr) :
+                cnull ("/dev/null")
+            {}
+            inline  ~Commentator ()
+            {}
+            inline void start (const char *, const char * = (const char *) 0, unsigned long = 0)
+            {}
+            inline void startIteration (unsigned int , unsigned long = 0)
+            {}
+            inline void stop (const char *, const char * = (const char *) 0, const char * = (const char *) 0)
+            {}
+            inline void progress (long = -1, long = -1)
+            {}
 
-		enum MessageLevel {
-			LEVEL_ALWAYS       =  0,
-			LEVEL_IMPORTANT    =  1,
-			LEVEL_NORMAL       =  2,
-			LEVEL_UNIMPORTANT  =  3
-		};
+            enum MessageLevel {
+                LEVEL_ALWAYS       =  0,
+                LEVEL_IMPORTANT    =  1,
+                LEVEL_NORMAL       =  2,
+                LEVEL_UNIMPORTANT  =  3
+            };
 
-		inline std::ostream &report (long level = LEVEL_IMPORTANT, const char *msg_class = INTERNAL_DESCRIPTION)
-		{
-		       	return cnull;
-		}
+            inline std::ostream &report (long level = LEVEL_IMPORTANT, const char *msg_class = INTERNAL_DESCRIPTION)
+            {
+                return cnull;
+            }
 
-		inline void indent (std::ostream &)
-		{}
+            inline void indent (std::ostream &)
+            {}
 
-		enum OutputFormat {
-		       	OUTPUT_CONSOLE,
-			OUTPUT_PIPE
-		};
+            enum OutputFormat {
+                OUTPUT_CONSOLE,
+                OUTPUT_PIPE
+            };
 
-		enum EstimationMethod {
-			BEST_ESTIMATE,
-			POLY_ESTIMATE,
-			EXPO_ESTIMATE
-		};
+            enum EstimationMethod {
+                BEST_ESTIMATE,
+                POLY_ESTIMATE,
+                EXPO_ESTIMATE
+            };
 
-		enum TimingDelay {
-			SHORT_TIMING,
-			LONG_TIMING
-		};
+            enum TimingDelay {
+                SHORT_TIMING,
+                LONG_TIMING
+            };
 
-		inline void setMaxDepth (long )
-	       	{}
-		inline void setMaxDetailLevel (long )
-		{}
-		inline MessageClass &registerMessageClass (const char *, std::ostream &, unsigned long = 1, unsigned long = 2)
-		{ return _msgcls; }
-		inline MessageClass &cloneMessageClass (const char *, const char *)
-		{ return _msgcls; }
-		inline MessageClass &cloneMessageClass (const char *, const char *, std::ostream &)
-		{ return _msgcls; }
-		inline MessageClass &getMessageClass (const char *)
-		{ return _msgcls; }
-		inline void setPrintParameters (unsigned long , unsigned long , const char * = (const char *) 0)
-	       	{}
-		inline void setBriefReportParameters (OutputFormat , bool , bool , bool )
-	       	{}
-		inline bool isPrinted (unsigned long , unsigned long , const char *, const char * = (const char *) 0)
-		{ return false; }
-		inline bool isPrinted (unsigned long , const char *, const char * = (const char *) 0)
-		{ return false; }
-		inline bool isNullStream (const std::ostream &)
-		{ return true; }
-		inline void setBriefReportStream (std::ostream &)
-		{}
-		inline void setReportStream (std::ostream &)
-	       	{}
-		inline void setMessageClassStream (const char *, std::ostream &)
-	       	{}
-		inline void setDefaultReportFile (const char *)
-	       	{}
-		inline void start (const char *, const char *, long , const char *)
-	       	{}
-		inline void stop (const char *, long , const char *, long)
-	       	{}
-		inline void progress (const char *, long , long , long )
-	       	{}
-		inline void report (const char *, long , const char *)
-	       	{}
-		inline bool printed (long , const char *)
-		{ return false; }
+            inline void setMaxDepth (long )
+            {}
+            inline void setMaxDetailLevel (long )
+            {}
+            inline MessageClass &registerMessageClass (const char *, std::ostream &, unsigned long = 1, unsigned long = 2)
+            { return _msgcls; }
+            inline MessageClass &cloneMessageClass (const char *, const char *)
+            { return _msgcls; }
+            inline MessageClass &cloneMessageClass (const char *, const char *, std::ostream &)
+            { return _msgcls; }
+            inline MessageClass &getMessageClass (const char *)
+            { return _msgcls; }
+            inline void setPrintParameters (unsigned long , unsigned long , const char * = (const char *) 0)
+            {}
+            inline void setBriefReportParameters (OutputFormat , bool , bool , bool )
+            {}
+            inline bool isPrinted (unsigned long , unsigned long , const char *, const char * = (const char *) 0)
+            { return false; }
+            inline bool isPrinted (unsigned long , const char *, const char * = (const char *) 0)
+            { return false; }
+            inline bool isNullStream (const std::ostream &)
+            { return true; }
+            inline void setBriefReportStream (std::ostream &)
+            {}
+            inline void setReportStream (std::ostream &)
+            {}
+            inline void setMessageClassStream (const char *, std::ostream &)
+            {}
+            inline void setDefaultReportFile (const char *)
+            {}
+            inline void start (const char *, const char *, long , const char *)
+            {}
+            inline void stop (const char *, long , const char *, long)
+            {}
+            inline void progress (const char *, long , long , long )
+            {}
+            inline void report (const char *, long , const char *)
+            {}
+            inline bool printed (long , const char *)
+            { return false; }
 
-		ActivityState saveActivityState () const
-		{ return ActivityState(); }
-		void restoreActivityState (ActivityState state)
-		{}
+            ActivityState saveActivityState () const
+            { return ActivityState(); }
+            void restoreActivityState (ActivityState state)
+            {}
 
-		std::ofstream cnull;
+            std::ofstream cnull;
 
-	private:
+        private:
 #if 0
-		// Null std::ostream prints nothing
-		struct nullstreambuf : public std::streambuf {
-			nullstreambuf () {};
-			~nullstreambuf () {};
-			inline std::streampos seekoff (std::streambuf::off_type, std::ios::seekdir, std::ios::openmode)
-			{
-			       	return 0;
-			}
-			inline std::streampos seekpos (std::streambuf::pos_type, std::ios::openmode)
-			{
-			       	return 0;
-			}
-			inline std::streampos sys_seek (std::streambuf::off_type, std::ios::seekdir)
-			{
-			       	return 0;
-			}
-			inline std::streamsize showmanyc ()
-			{
-			       	return 0;
-			}
-			inline void imbue (const std::locale &loc) {}
-		};
+            // Null std::ostream prints nothing
+            struct nullstreambuf : public std::streambuf {
+                nullstreambuf () {};
+                ~nullstreambuf () {};
+                inline std::streampos seekoff (std::streambuf::off_type, std::ios::seekdir, std::ios::openmode)
+                {
+                    return 0;
+                }
+                inline std::streampos seekpos (std::streambuf::pos_type, std::ios::openmode)
+                {
+                    return 0;
+                }
+                inline std::streampos sys_seek (std::streambuf::off_type, std::ios::seekdir)
+                {
+                    return 0;
+                }
+                inline std::streamsize showmanyc ()
+                {
+                    return 0;
+                }
+                inline void imbue (const std::locale &loc) {}
+            };
 #endif
 
-		MessageClass _msgcls;
-	}; // class (disabled) Commentator
+            MessageClass _msgcls;
+        }; // class (disabled) Commentator
 
-// 	// Default global commentator
-// 	extern Commentator commentator;
-// 	//static Commentator commentator;
-}
+        // 	// Default global commentator
+        // 	extern Commentator commentator;
+        // 	//static Commentator commentator;
+    }
 
 #endif // DISABLE_COMMENTATOR
 
-namespace LinBox
-{
-	// Default static commentator
-    Commentator& commentator() {
-        static Commentator internal_static_commentator;
-        return internal_static_commentator;
+    namespace LinBox
+    {
+        // Default static commentator
+        Commentator& commentator() {
+            static Commentator internal_static_commentator;
+            return internal_static_commentator;
+        }
+        Commentator& commentator(std::ostream& stream) {
+            static Commentator internal_static_commentator(stream);
+            return internal_static_commentator;
+        }
     }
-    Commentator& commentator(std::ostream& stream) {
-        static Commentator internal_static_commentator(stream);
-        return internal_static_commentator;
-    }
-}
 
 
 
 
 #include "linbox/util/args-parser.h"
-namespace LinBox
-{
-    void parseArguments (int argc, char **argv, Argument *args, bool printDefaults = true) {
-        for (int i = 1; i < argc; ++i) {
-            if (argv[i][0] == '-') {
-                if (argv[i][1] == 0) {
-                    LinBox::commentator().setReportStream (std::cout);
-                    LinBox::commentator().setBriefReportStream (std::cout);
-                } else {
+    namespace LinBox
+    {
+        void parseArguments (int argc, char **argv, Argument *args, bool printDefaults = true) {
+            for (int i = 1; i < argc; ++i) {
+                if (argv[i][0] == '-') {
+                    if (argv[i][1] == 0) {
+                        LinBox::commentator().setReportStream (std::cout);
+                        LinBox::commentator().setBriefReportStream (std::cout);
+                    } else {
                         // Skip the argument next to "-xxx"
                         // except if next argument is a switch
-                    if ( ((i+1) < argc) &&
-                         (argv[i+1][0] != '-') ) {
-                        ++i;
+                        if ( ((i+1) < argc) &&
+                             (argv[i+1][0] != '-') ) {
+                            ++i;
+                        }
                     }
+                } else {
+                    LinBox::commentator().setDefaultReportFile (argv[i]);
+                    LinBox::commentator().setBriefReportStream(std::cout);
                 }
-            } else {
-                LinBox::commentator().setDefaultReportFile (argv[i]);
-                LinBox::commentator().setBriefReportStream(std::cout);
             }
+            FFLAS::parseArguments(argc,argv,args,printDefaults);
         }
-        FFLAS::parseArguments(argc,argv,args,printDefaults);
     }
-}
 
 #endif // __LINBOX_commentator_H
 
-// Local Variables:
-// mode: C++
-// tab-width: 4
-// indent-tabs-mode: nil
-// c-basic-offset: 4
-// End:
-// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s
+    // Local Variables:
+    // mode: C++
+    // tab-width: 4
+    // indent-tabs-mode: nil
+    // c-basic-offset: 4
+    // End:
+    // vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s

--- a/linbox/util/commentator.h
+++ b/linbox/util/commentator.h
@@ -864,7 +864,7 @@ namespace LinBox
 		{}
 #endif
 		inline Commentator (std::ostream& out = std::cerr) :
-			cnull (0)
+            cnull ("/dev/null")
 		{}
 		inline  ~Commentator ()
 	       	{}

--- a/linbox/util/commentator.inl
+++ b/linbox/util/commentator.inl
@@ -86,9 +86,7 @@ namespace LinBox
 	}
 
 	Commentator::Commentator () :
-		// cnull (new nullstreambuf)
 		cnull ("/dev/null")
-		// cnull (0) // this is not right (clang/valgrind complain)
 		, _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
 		_show_timing (true), _show_progress (true), _show_est_time (true)
 		,_last_line_len(0)
@@ -104,9 +102,7 @@ namespace LinBox
 		registerMessageClass (INTERNAL_DESCRIPTION, _report);
 	}
 	Commentator::Commentator (std::ostream& out) :
-		// cnull (new nullstreambuf)
-// 		cnull ("/dev/null")
-		cnull (0)
+		cnull ("/dev/null")
 		, _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
 		_show_timing (true), _show_progress (true), _show_est_time (true)
 		,_last_line_len(0)

--- a/linbox/util/commentator.inl
+++ b/linbox/util/commentator.inl
@@ -10,7 +10,7 @@
  * ========LICENCE========
  * This file is part of the library LinBox.
  *
-  * LinBox is free software: you can redistribute it and/or modify
+ * LinBox is free software: you can redistribute it and/or modify
  * it under the terms of the  GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
@@ -50,715 +50,715 @@
 
 namespace LinBox
 {
-	// -----------------------------------------------------
-	// Mathematical routines
-	// -----------------------------------------------------
-	double nroot (double a, long r, double precision)
-	{
-		const long rm = r - 1 ;
-		const double c1 = double (rm) / double (r), c2 = a / double (r);
-		double g = 1, pgr = 1, err = a - 1;
+    // -----------------------------------------------------
+    // Mathematical routines
+    // -----------------------------------------------------
+    double nroot (double a, long r, double precision)
+    {
+        const long rm = r - 1 ;
+        const double c1 = double (rm) / double (r), c2 = a / double (r);
+        double g = 1, pgr = 1, err = a - 1;
 
-		while (err > precision) {
-			g = g * c1 + c2 / pgr;
-			pgr = pow (g, (double) rm);
-			err = a - pgr * g; if (err < 0) err = -err;
-		}
+        while (err > precision) {
+            g = g * c1 + c2 / pgr;
+            pgr = pow (g, (double) rm);
+            err = a - pgr * g; if (err < 0) err = -err;
+        }
 
-		return g;
-	}
+        return g;
+    }
 
-	long isnpower (long& l, long a)
-	{
-		long r = 2;
-		double g;
+    long isnpower (long& l, long a)
+    {
+        long r = 2;
+        double g;
 
-		while ((g = nroot ((double)a, r, 0.1)) >= 2) {
-			l = (long) floor (g);
-			if (g-double (l) > 0.1)
-				++l;
-			if (Givaro::power (l, r) == a)
-				return r;
-			++r;
-		}
+        while ((g = nroot ((double)a, r, 0.1)) >= 2) {
+            l = (long) floor (g);
+            if (g-double (l) > 0.1)
+                ++l;
+            if (Givaro::power (l, r) == a)
+                return r;
+            ++r;
+        }
 
-		return 0;
-	}
+        return 0;
+    }
 
-	Commentator::Commentator () :
-		cnull ("/dev/null")
-		, _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
-		_show_timing (true), _show_progress (true), _show_est_time (true)
-		,_last_line_len(0)
-	{
-		//registerMessageClass (BRIEF_REPORT,         std::clog, 1, LEVEL_IMPORTANT);
-		registerMessageClass (BRIEF_REPORT,         _report, 1, LEVEL_IMPORTANT);
-		registerMessageClass (PROGRESS_REPORT,      _report);
-		registerMessageClass (TIMING_MEASURE,       _report);
-		registerMessageClass (TIMING_ESTIMATE,      _report);
-		registerMessageClass (PARTIAL_RESULT,       _report);
-		registerMessageClass (INTERNAL_WARNING,     _report, 10, LEVEL_NORMAL);
-		registerMessageClass (INTERNAL_ERROR,       _report, 10, LEVEL_NORMAL);
-		registerMessageClass (INTERNAL_DESCRIPTION, _report);
-	}
-	Commentator::Commentator (std::ostream& out) :
-		cnull ("/dev/null")
-		, _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
-		_show_timing (true), _show_progress (true), _show_est_time (true)
-		,_last_line_len(0)
-	{
-		//registerMessageClass (BRIEF_REPORT,         out, 1, LEVEL_IMPORTANT);
-		registerMessageClass (BRIEF_REPORT,         out, 1, LEVEL_IMPORTANT);
-		registerMessageClass (PROGRESS_REPORT,      out);
-		registerMessageClass (TIMING_MEASURE,       out);
-		registerMessageClass (TIMING_ESTIMATE,      out);
-		registerMessageClass (PARTIAL_RESULT,       out);
-		registerMessageClass (INTERNAL_WARNING,     out, 10, LEVEL_NORMAL);
-		registerMessageClass (INTERNAL_ERROR,       out, 10, LEVEL_NORMAL);
-		registerMessageClass (INTERNAL_DESCRIPTION, out);
-	}
+    Commentator::Commentator () :
+        cnull ("/dev/null")
+        , _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
+        _show_timing (true), _show_progress (true), _show_est_time (true)
+        ,_last_line_len(0)
+    {
+        //registerMessageClass (BRIEF_REPORT,         std::clog, 1, LEVEL_IMPORTANT);
+        registerMessageClass (BRIEF_REPORT,         _report, 1, LEVEL_IMPORTANT);
+        registerMessageClass (PROGRESS_REPORT,      _report);
+        registerMessageClass (TIMING_MEASURE,       _report);
+        registerMessageClass (TIMING_ESTIMATE,      _report);
+        registerMessageClass (PARTIAL_RESULT,       _report);
+        registerMessageClass (INTERNAL_WARNING,     _report, 10, LEVEL_NORMAL);
+        registerMessageClass (INTERNAL_ERROR,       _report, 10, LEVEL_NORMAL);
+        registerMessageClass (INTERNAL_DESCRIPTION, _report);
+    }
+    Commentator::Commentator (std::ostream& out) :
+        cnull ("/dev/null")
+        , _estimationMethod (BEST_ESTIMATE), _format (OUTPUT_CONSOLE),
+        _show_timing (true), _show_progress (true), _show_est_time (true)
+        ,_last_line_len(0)
+    {
+        //registerMessageClass (BRIEF_REPORT,         out, 1, LEVEL_IMPORTANT);
+        registerMessageClass (BRIEF_REPORT,         out, 1, LEVEL_IMPORTANT);
+        registerMessageClass (PROGRESS_REPORT,      out);
+        registerMessageClass (TIMING_MEASURE,       out);
+        registerMessageClass (TIMING_ESTIMATE,      out);
+        registerMessageClass (PARTIAL_RESULT,       out);
+        registerMessageClass (INTERNAL_WARNING,     out, 10, LEVEL_NORMAL);
+        registerMessageClass (INTERNAL_ERROR,       out, 10, LEVEL_NORMAL);
+        registerMessageClass (INTERNAL_DESCRIPTION, out);
+    }
 
-	Commentator::~Commentator()
-	{
-	    _report << "That's all, Folks!" << std::endl;
-		std::map <const char *, MessageClass *, C_str_Less >::iterator i;
-		for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
-			delete i->second;
-		while (!_activities.empty()){
-			delete _activities.top();
-			_activities.pop();
-		}
-	}
+    Commentator::~Commentator()
+    {
+        _report << "That's all, Folks!" << std::endl;
+        std::map <const char *, MessageClass *, C_str_Less >::iterator i;
+        for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
+            delete i->second;
+        while (!_activities.empty()){
+            delete _activities.top();
+            _activities.pop();
+        }
+    }
 
-	void Commentator::start (const char *description, const char *fn, unsigned long len)
-	{
-		if (fn == (const char *) 0 && _activities.size () > 0)
-			fn = _activities.top ()->_fn;
+    void Commentator::start (const char *description, const char *fn, unsigned long len)
+    {
+        if (fn == (const char *) 0 && _activities.size () > 0)
+            fn = _activities.top ()->_fn;
 
-		if (isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn))
-			report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION) //<< "Starting activity: "
-			<< description << std::endl;
+        if (isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn))
+            report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION) //<< "Starting activity: "
+            << description << std::endl;
 
-		Activity *new_act = new Activity (description, fn, len);
+        Activity *new_act = new Activity (description, fn, len);
 
-		if (isPrinted (_activities.size (), LEVEL_IMPORTANT, BRIEF_REPORT, fn))
-			printActivityReport (*new_act);
+        if (isPrinted (_activities.size (), LEVEL_IMPORTANT, BRIEF_REPORT, fn))
+            printActivityReport (*new_act);
 
-		_activities.push (new_act);
+        _activities.push (new_act);
 
-		new_act->_timer.start ();
-	}
+        new_act->_timer.start ();
+    }
 
-	void Commentator::start (std::string description, const char *fn, unsigned long len)
-	{
-		start(description.c_str(),fn,len);
-	}
+    void Commentator::start (std::string description, const char *fn, unsigned long len)
+    {
+        start(description.c_str(),fn,len);
+    }
 
-	void Commentator::startIteration (unsigned int iter, unsigned long len)
-	{
-		std::ostringstream str;
+    void Commentator::startIteration (unsigned int iter, unsigned long len)
+    {
+        std::ostringstream str;
 
-		str << "Iteration " << iter << std::ends;
+        str << "Iteration " << iter << std::ends;
 
-		_iteration_str = str.str ();
-		start (_iteration_str.c_str (), (const char *) 0, len);
-	}
+        _iteration_str = str.str ();
+        start (_iteration_str.c_str (), (const char *) 0, len);
+    }
 
-	void Commentator::stop (const char *msg, const char *long_msg, const char *fn)
-	{
-		double realtime; //, usertime, systime;
-		Activity *top_act;
+    void Commentator::stop (const char *msg, const char *long_msg, const char *fn)
+    {
+        double realtime; //, usertime, systime;
+        Activity *top_act;
 
-		linbox_check (_activities.top () != (Activity *) 0);
-		linbox_check (msg != (const char *) 0);
+        linbox_check (_activities.top () != (Activity *) 0);
+        linbox_check (msg != (const char *) 0);
 
-		if (long_msg == (const char *) 0)
-			long_msg = msg;
+        if (long_msg == (const char *) 0)
+            long_msg = msg;
 
-		top_act = _activities.top ();
+        top_act = _activities.top ();
 
-		top_act->_timer.stop ();
+        top_act->_timer.stop ();
 
-		realtime = top_act->_timer.time ();
-		//usertime = top_act->_timer.usertime ();
-		//systime  = top_act->_timer.systime ();
+        realtime = top_act->_timer.time ();
+        //usertime = top_act->_timer.usertime ();
+        //systime  = top_act->_timer.systime ();
 
-		if (realtime < 0) realtime = 0;
-		//if (usertime < 0) usertime = 0;
-		//if (systime < 0) systime = 0;
+        if (realtime < 0) realtime = 0;
+        //if (usertime < 0) usertime = 0;
+        //if (systime < 0) systime = 0;
 
-		if (fn != (const char *) 0 &&
-		    _activities.size () > 0 &&
-		    top_act->_fn != (const char *) 0 &&
-		    strcmp (fn, top_act->_fn) != 0)
-		{
-			report (LEVEL_IMPORTANT, INTERNAL_WARNING)
-			<< "Activity report mismatch. Check that start () and stop () calls are paired correctly." << std::endl;
-		}
+        if (fn != (const char *) 0 &&
+            _activities.size () > 0 &&
+            top_act->_fn != (const char *) 0 &&
+            strcmp (fn, top_act->_fn) != 0)
+        {
+            report (LEVEL_IMPORTANT, INTERNAL_WARNING)
+            << "Activity report mismatch. Check that start () and stop () calls are paired correctly." << std::endl;
+        }
 
-		fn = top_act->_fn;
+        fn = top_act->_fn;
 
-		_activities.pop ();
+        _activities.pop ();
 
-		if (isPrinted (_activities.size (), LEVEL_IMPORTANT, BRIEF_REPORT, fn))
-		{
-			finishActivityReport (*top_act, msg);
-		}
+        if (isPrinted (_activities.size (), LEVEL_IMPORTANT, BRIEF_REPORT, fn))
+        {
+            finishActivityReport (*top_act, msg);
+        }
 
-		if (isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn)) {
-			std::ostream &output = report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION);
-			output.precision (4);
-			output << "Finished activity (rea: " << realtime << "s, cpu: ";
-			//output.precision (4);
-			//output << usertime << "s, sys: ";
-			//output.precision (4);
-			//output << systime << "s): " << long_msg << std::endl;
-		}
-		else if (isPrinted (_activities.size (), LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn)) {
-			std::ostream &output = report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION);
-			output.precision (4);
-			output << "Completed activity: " << top_act->_desc << " (r: " << realtime << "s, u: ";
-			//output.precision (4);
-			//output << usertime << "s, s: ";
-			//output.precision (4);
-			//output << systime << "s) " << long_msg << std::endl;
-		}
+        if (isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn)) {
+            std::ostream &output = report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION);
+            output.precision (4);
+            output << "Finished activity (rea: " << realtime << "s, cpu: ";
+            //output.precision (4);
+            //output << usertime << "s, sys: ";
+            //output.precision (4);
+            //output << systime << "s): " << long_msg << std::endl;
+        }
+        else if (isPrinted (_activities.size (), LEVEL_IMPORTANT, INTERNAL_DESCRIPTION, fn)) {
+            std::ostream &output = report (LEVEL_IMPORTANT, INTERNAL_DESCRIPTION);
+            output.precision (4);
+            output << "Completed activity: " << top_act->_desc << " (r: " << realtime << "s, u: ";
+            //output.precision (4);
+            //output << usertime << "s, s: ";
+            //output.precision (4);
+            //output << systime << "s) " << long_msg << std::endl;
+        }
 
-		delete top_act;
-	}
+        delete top_act;
+    }
 
-	void Commentator::progress (long k, long len)
-	{
-		linbox_check (_activities.top () != (Activity *) 0);
+    void Commentator::progress (long k, long len)
+    {
+        linbox_check (_activities.top () != (Activity *) 0);
 
-		Activity *act = _activities.top ();
-		Givaro::RealTimer tmp = act->_timer;
-		act->_timer.stop ();
+        Activity *act = _activities.top ();
+        Givaro::RealTimer tmp = act->_timer;
+        act->_timer.stop ();
 
-		if (k == -1)
-			++(act->_progress);
-		else
-			act->_progress = (unsigned long)k;
+        if (k == -1)
+            ++(act->_progress);
+        else
+            act->_progress = (unsigned long)k;
 
-		if (len != -1)
-			act->_len = (unsigned long) len;
+        if (len != -1)
+            act->_len = (unsigned long) len;
 
-		if (act->_progress > act->_len)
-			act->_len = act->_progress;
+        if (act->_progress > act->_len)
+            act->_len = act->_progress;
 
-		std::ostream &rep = report (LEVEL_IMPORTANT, PROGRESS_REPORT);
-		rep.precision (3);
-		rep.setf (std::ios::fixed);
-		rep << "Progress: " << act->_progress << " out of " << act->_len
-		<< " (" << act->_timer.time () << "s elapsed)" << std::endl;
+        std::ostream &rep = report (LEVEL_IMPORTANT, PROGRESS_REPORT);
+        rep.precision (3);
+        rep.setf (std::ios::fixed);
+        rep << "Progress: " << act->_progress << " out of " << act->_len
+        << " (" << act->_timer.time () << "s elapsed)" << std::endl;
 
-		if (_show_progress && isPrinted (_activities.size () - 1, LEVEL_IMPORTANT, BRIEF_REPORT, act->_fn))
-			updateActivityReport (*act);
-		act->_timer = tmp;
-	}
+        if (_show_progress && isPrinted (_activities.size () - 1, LEVEL_IMPORTANT, BRIEF_REPORT, act->_fn))
+            updateActivityReport (*act);
+        act->_timer = tmp;
+    }
 
-	std::ostream &Commentator::report (long level, const char *msg_class)
-	{
-		linbox_check (msg_class != (const char *) 0);
+    std::ostream &Commentator::report (long level, const char *msg_class)
+    {
+        linbox_check (msg_class != (const char *) 0);
 
-	    _report << "$$(" << _activities.size () << ", " << level << ", " << msg_class << ")";
+        _report << "$$(" << _activities.size () << ", " << level << ", " << msg_class << ")";
 #if 0
-	    if (!isPrinted (_activities.size (), level, msg_class,
-				    (_activities.size () > 0) ? _activities.top ()->_fn : (const char *) 0))
-		    return cnull;
+        if (!isPrinted (_activities.size (), level, msg_class,
+                        (_activities.size () > 0) ? _activities.top ()->_fn : (const char *) 0))
+            return cnull;
 
-	    MessageClass &messageClass = getMessageClass (msg_class);
+        MessageClass &messageClass = getMessageClass (msg_class);
 
-	    return messageClass._stream;
+        return messageClass._stream;
 #endif
-		return _report;
-	}
+        return _report;
+    }
 
-	void Commentator::indent (std::ostream &stream) const
-	{
-		unsigned int i;
+    void Commentator::indent (std::ostream &stream) const
+    {
+        unsigned int i;
 
-		for (i = 0; i < _activities.size (); ++i)
-			stream << "  ";
-	}
+        for (i = 0; i < _activities.size (); ++i)
+            stream << "  ";
+    }
 
-	void Commentator::restoreActivityState (ActivityState state)
-	{
-		std::stack<Activity *> backup;
+    void Commentator::restoreActivityState (ActivityState state)
+    {
+        std::stack<Activity *> backup;
 
-		while (!_activities.empty () && _activities.top () != state._act) {
-			backup.push (_activities.top ());
-			_activities.pop ();
-		}
+        while (!_activities.empty () && _activities.top () != state._act) {
+            backup.push (_activities.top ());
+            _activities.pop ();
+        }
 
-		if (_activities.empty ()) {
-			// Uh oh -- the state didn't give a valid activity
+        if (_activities.empty ()) {
+            // Uh oh -- the state didn't give a valid activity
 
-			while (!backup.empty ()) {
-				_activities.push (backup.top ());
-				backup.pop ();
-			}
-		}
-	}
+            while (!backup.empty ()) {
+                _activities.push (backup.top ());
+                backup.pop ();
+            }
+        }
+    }
 
-	void Commentator::setMaxDepth (long depth)
-	{
-		MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
-		std::map <const char *, MessageClass *, C_str_Less>::iterator i;
+    void Commentator::setMaxDepth (long depth)
+    {
+        MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
+        std::map <const char *, MessageClass *, C_str_Less>::iterator i;
 
-		for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
-			if (i->second != &briefReportClass)
-				i->second->setMaxDepth (depth);
-	}
+        for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
+            if (i->second != &briefReportClass)
+                i->second->setMaxDepth (depth);
+    }
 
-	void Commentator::setMaxDetailLevel (long level)
-	{
-		MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
-		std::map <const char *, MessageClass *, C_str_Less>::iterator i;
+    void Commentator::setMaxDetailLevel (long level)
+    {
+        MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
+        std::map <const char *, MessageClass *, C_str_Less>::iterator i;
 
-		for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
-			if (i->second != &briefReportClass)
-				i->second->setMaxDetailLevel (level);
-	}
+        for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
+            if (i->second != &briefReportClass)
+                i->second->setMaxDetailLevel (level);
+    }
 
-	MessageClass &Commentator::registerMessageClass (const char *msg_class, std::ostream &stream, unsigned long max_depth, unsigned long max_level)
-	{
-		linbox_check (msg_class != (const char *) 0);
+    MessageClass &Commentator::registerMessageClass (const char *msg_class, std::ostream &stream, unsigned long max_depth, unsigned long max_level)
+    {
+        linbox_check (msg_class != (const char *) 0);
 
-		MessageClass *new_obj = new MessageClass (*this, msg_class, stream, max_depth, max_level);
-		_messageClasses[msg_class] = new_obj;
-		return *new_obj;
-	}
+        MessageClass *new_obj = new MessageClass (*this, msg_class, stream, max_depth, max_level);
+        _messageClasses[msg_class] = new_obj;
+        return *new_obj;
+    }
 
-	MessageClass &Commentator::cloneMessageClass (const char *new_msg_class, const char *msg_class)
-	{
-		linbox_check (new_msg_class != (const char *) 0);
-		linbox_check (msg_class != (const char *) 0);
+    MessageClass &Commentator::cloneMessageClass (const char *new_msg_class, const char *msg_class)
+    {
+        linbox_check (new_msg_class != (const char *) 0);
+        linbox_check (msg_class != (const char *) 0);
 
-		MessageClass *new_obj = new MessageClass (getMessageClass (msg_class));
-		new_obj->_msg_class = new_msg_class;
-		_messageClasses[new_msg_class] = new_obj;
-		return *new_obj;
-	}
+        MessageClass *new_obj = new MessageClass (getMessageClass (msg_class));
+        new_obj->_msg_class = new_msg_class;
+        _messageClasses[new_msg_class] = new_obj;
+        return *new_obj;
+    }
 
-	MessageClass &Commentator::cloneMessageClass (const char *new_msg_class, const char *msg_class, std::ostream &stream)
-	{
-		linbox_check (new_msg_class != (const char *) 0);
-		linbox_check (msg_class != (const char *) 0);
+    MessageClass &Commentator::cloneMessageClass (const char *new_msg_class, const char *msg_class, std::ostream &stream)
+    {
+        linbox_check (new_msg_class != (const char *) 0);
+        linbox_check (msg_class != (const char *) 0);
 
-		MessageClass &old_obj = getMessageClass (msg_class);
-		MessageClass *new_obj = new MessageClass (*this, new_msg_class, stream, old_obj._configuration);
-		_messageClasses[new_msg_class] = new_obj;
-		return *new_obj;
-	}
+        MessageClass &old_obj = getMessageClass (msg_class);
+        MessageClass *new_obj = new MessageClass (*this, new_msg_class, stream, old_obj._configuration);
+        _messageClasses[new_msg_class] = new_obj;
+        return *new_obj;
+    }
 
-	MessageClass &Commentator::getMessageClass (const char *msg_class)
-	{ return *_messageClasses[msg_class]; }
+    MessageClass &Commentator::getMessageClass (const char *msg_class)
+    { return *_messageClasses[msg_class]; }
 
-	void Commentator::setPrintParameters (unsigned long depth, unsigned long level, const char *fn)
-	{
-		MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
-		std::map <const char *, MessageClass *, C_str_Less>::iterator i;
+    void Commentator::setPrintParameters (unsigned long depth, unsigned long level, const char *fn)
+    {
+        MessageClass &briefReportClass = getMessageClass (BRIEF_REPORT);
+        std::map <const char *, MessageClass *, C_str_Less>::iterator i;
 
-		for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
-			if (i->second != &briefReportClass)
-				i->second->setPrintParameters (depth, level, fn);
-	}
+        for (i = _messageClasses.begin (); i != _messageClasses.end (); ++i)
+            if (i->second != &briefReportClass)
+                i->second->setPrintParameters (depth, level, fn);
+    }
 
-	void Commentator::setBriefReportParameters (OutputFormat format, bool show_timing, bool show_progress, bool show_est_time)
-	{
-		_format        = format;
-		_show_timing   = show_timing;
-		_show_progress = show_progress;
-		_show_est_time = show_est_time;
-	}
+    void Commentator::setBriefReportParameters (OutputFormat format, bool show_timing, bool show_progress, bool show_est_time)
+    {
+        _format        = format;
+        _show_timing   = show_timing;
+        _show_progress = show_progress;
+        _show_est_time = show_est_time;
+    }
 
-	bool Commentator::isPrinted (unsigned long depth, unsigned long level, const char *msg_class, const char *fn)
-	{
-		if (_messageClasses.find (msg_class) == _messageClasses.end ())
-			return false;
+    bool Commentator::isPrinted (unsigned long depth, unsigned long level, const char *msg_class, const char *fn)
+    {
+        if (_messageClasses.find (msg_class) == _messageClasses.end ())
+            return false;
 
-		MessageClass &messageClass = getMessageClass (msg_class);
+        MessageClass &messageClass = getMessageClass (msg_class);
 
-		return messageClass.isPrinted (depth, level, fn);
-	}
+        return messageClass.isPrinted (depth, level, fn);
+    }
 
-	void Commentator::setBriefReportStream (std::ostream &stream)
-	{ setMessageClassStream (BRIEF_REPORT, stream); }
+    void Commentator::setBriefReportStream (std::ostream &stream)
+    { setMessageClassStream (BRIEF_REPORT, stream); }
 
-	void Commentator::setReportStream (std::ostream &stream)
-	{
-		setMessageClassStream (BRIEF_REPORT,      stream);
-		setMessageClassStream (PROGRESS_REPORT,      stream);
-		setMessageClassStream (TIMING_MEASURE,       stream);
-		setMessageClassStream (TIMING_ESTIMATE,      stream);
-		setMessageClassStream (PARTIAL_RESULT,       stream);
-		setMessageClassStream (INTERNAL_ERROR,       stream);
-		setMessageClassStream (INTERNAL_WARNING,     stream);
-		setMessageClassStream (INTERNAL_DESCRIPTION, stream);
+    void Commentator::setReportStream (std::ostream &stream)
+    {
+        setMessageClassStream (BRIEF_REPORT,      stream);
+        setMessageClassStream (PROGRESS_REPORT,      stream);
+        setMessageClassStream (TIMING_MEASURE,       stream);
+        setMessageClassStream (TIMING_ESTIMATE,      stream);
+        setMessageClassStream (PARTIAL_RESULT,       stream);
+        setMessageClassStream (INTERNAL_ERROR,       stream);
+        setMessageClassStream (INTERNAL_WARNING,     stream);
+        setMessageClassStream (INTERNAL_DESCRIPTION, stream);
 
-		if (&stream == &(getMessageClass (BRIEF_REPORT)._stream))
-			getMessageClass (BRIEF_REPORT).setMaxDepth (0);
-	}
+        if (&stream == &(getMessageClass (BRIEF_REPORT)._stream))
+            getMessageClass (BRIEF_REPORT).setMaxDepth (0);
+    }
 
-	void Commentator::setMessageClassStream (const char *msg_class, std::ostream &stream)
-	{
-		//temporarily fixed the bug in test-commentator, left memory leaking.
-		MessageClass *old_msg_class = _messageClasses[msg_class];
-		cloneMessageClass (msg_class, msg_class, stream);
-		delete old_msg_class;
+    void Commentator::setMessageClassStream (const char *msg_class, std::ostream &stream)
+    {
+        //temporarily fixed the bug in test-commentator, left memory leaking.
+        MessageClass *old_msg_class = _messageClasses[msg_class];
+        cloneMessageClass (msg_class, msg_class, stream);
+        delete old_msg_class;
 
-	}
+    }
 
-	void Commentator::setDefaultReportFile (const char *filename)
-	{
-		_report.open (filename);
-	}
+    void Commentator::setDefaultReportFile (const char *filename)
+    {
+        _report.open (filename);
+    }
 
-	void Commentator::printActivityReport (Activity &activity)
-	{
-		MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
+    void Commentator::printActivityReport (Activity &activity)
+    {
+        MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
 
-		if (_format == OUTPUT_CONSOLE) {
-			messageClass._stream << activity._desc << "...";
+        if (_format == OUTPUT_CONSOLE) {
+            messageClass._stream << activity._desc << "...";
 
-			if (messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn))
-				messageClass._stream << std::endl;
-			else if (_show_progress && activity._len > 0) {
-				messageClass._stream << "  0%";
-				_last_line_len = (int)strlen ("  0%");
-			}
-			else
-				_last_line_len = 0;
+            if (messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn))
+                messageClass._stream << std::endl;
+            else if (_show_progress && activity._len > 0) {
+                messageClass._stream << "  0%";
+                _last_line_len = (int)strlen ("  0%");
+            }
+            else
+                _last_line_len = 0;
 
-			messageClass._smart_streambuf.stream ().flush ();
-		}
-		else if (_format == OUTPUT_PIPE &&
-			 (((_show_progress || _show_est_time) && activity._len > 0) ||
-			  messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn)))
-		{
-			messageClass._stream << activity._desc << "...";
+            messageClass._smart_streambuf.stream ().flush ();
+        }
+        else if (_format == OUTPUT_PIPE &&
+                 (((_show_progress || _show_est_time) && activity._len > 0) ||
+                  messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn)))
+        {
+            messageClass._stream << activity._desc << "...";
 
-			if (_show_progress)
-				messageClass._stream << std::endl;
-		}
-	}
+            if (_show_progress)
+                messageClass._stream << std::endl;
+        }
+    }
 
-	void Commentator::updateActivityReport (Activity &activity)
-	{
-		MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
-		std::ostringstream str;
-		double percent = (double) activity._progress / (double) activity._len * 100.0;
+    void Commentator::updateActivityReport (Activity &activity)
+    {
+        MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
+        std::ostringstream str;
+        double percent = (double) activity._progress / (double) activity._len * 100.0;
 
-		if (_format == OUTPUT_CONSOLE) {
-			if (!messageClass.isPrinted (_activities.size (), LEVEL_IMPORTANT, activity._fn)) {
-				if (_show_progress) {
-			unsigned int i,  old_len;
-					for (i = 0; i < _last_line_len; ++i)
-						messageClass._stream << '\b';
-					str.width (3);
-					str << floor (percent + 0.5) << "%" << std::ends;
-					old_len = _last_line_len;
-					_last_line_len = (unsigned int)strlen (str.str ().c_str ());
-					messageClass._stream << str.str ();
-					for (int ii = 0; ii < (int) (old_len - _last_line_len); ++ii)
-						messageClass._stream << ' ';
-				}
-			}
-			else if (messageClass.isPrinted (_activities.size () - 1, LEVEL_UNIMPORTANT, activity._fn)) {
+        if (_format == OUTPUT_CONSOLE) {
+            if (!messageClass.isPrinted (_activities.size (), LEVEL_IMPORTANT, activity._fn)) {
+                if (_show_progress) {
+                    unsigned int i,  old_len;
+                    for (i = 0; i < _last_line_len; ++i)
+                        messageClass._stream << '\b';
+                    str.width (3);
+                    str << floor (percent + 0.5) << "%" << std::ends;
+                    old_len = _last_line_len;
+                    _last_line_len = (unsigned int)strlen (str.str ().c_str ());
+                    messageClass._stream << str.str ();
+                    for (int ii = 0; ii < (int) (old_len - _last_line_len); ++ii)
+                        messageClass._stream << ' ';
+                }
+            }
+            else if (messageClass.isPrinted (_activities.size () - 1, LEVEL_UNIMPORTANT, activity._fn)) {
 #if 0
-				if (_show_est_time)
-					messageClass._stream << activity._estimate.front ()._time
-					<< " remaining" << std::endl;
+                if (_show_est_time)
+                    messageClass._stream << activity._estimate.front ()._time
+                    << " remaining" << std::endl;
 #endif
-			}
+            }
 
-			messageClass._smart_streambuf.stream ().flush ();
-		}
-		else if (_format == OUTPUT_PIPE) {
-			if (_show_progress) {
-				messageClass._stream << floor (percent + 0.5) << "% done";
+            messageClass._smart_streambuf.stream ().flush ();
+        }
+        else if (_format == OUTPUT_PIPE) {
+            if (_show_progress) {
+                messageClass._stream << floor (percent + 0.5) << "% done";
 #if 0
-				if (_show_est_time)
-					messageClass._stream << " (" << activity._estimate.front ()._time
-					<< " remaining)";
+                if (_show_est_time)
+                    messageClass._stream << " (" << activity._estimate.front ()._time
+                    << " remaining)";
 #endif
-				messageClass._stream << std::endl;
-			}
+                messageClass._stream << std::endl;
+            }
 #if 0
-			else if (_show_est_time)
-				messageClass._stream << activity._estimate.front ()._time
-				<< " remaining" << std::endl;
+            else if (_show_est_time)
+                messageClass._stream << activity._estimate.front ()._time
+                << " remaining" << std::endl;
 #endif
-		}
-	}
+        }
+    }
 
-	void Commentator::finishActivityReport (Activity &activity, const char *msg)
-	{
-		MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
-		unsigned int i;
+    void Commentator::finishActivityReport (Activity &activity, const char *msg)
+    {
+        MessageClass &messageClass = getMessageClass (BRIEF_REPORT);
+        unsigned int i;
 
-		if (_format == OUTPUT_CONSOLE) {
-			if (!messageClass.isPrinted (_activities.size () + 1, LEVEL_UNIMPORTANT, activity._fn)) {
-				if (_show_progress)
-					for (i = 0; i < _last_line_len; ++i)
-						messageClass._stream << '\b';
+        if (_format == OUTPUT_CONSOLE) {
+            if (!messageClass.isPrinted (_activities.size () + 1, LEVEL_UNIMPORTANT, activity._fn)) {
+                if (_show_progress)
+                    for (i = 0; i < _last_line_len; ++i)
+                        messageClass._stream << '\b';
 
-				messageClass._stream << msg;
+                messageClass._stream << msg;
 
-				if (_show_timing)
-					messageClass._stream << " (" << activity._timer.time () << " s)" << std::endl;
-				else
-					messageClass._stream << std::endl;
-			}
-			else if (messageClass.isPrinted (_activities.size (), LEVEL_UNIMPORTANT, activity._fn)) {
-				for (i = 0; i < _activities.size (); ++i)
-					messageClass._stream << "  ";
+                if (_show_timing)
+                    messageClass._stream << " (" << activity._timer.time () << " s)" << std::endl;
+                else
+                    messageClass._stream << std::endl;
+            }
+            else if (messageClass.isPrinted (_activities.size (), LEVEL_UNIMPORTANT, activity._fn)) {
+                for (i = 0; i < _activities.size (); ++i)
+                    messageClass._stream << "  ";
 
-				messageClass._stream << msg;
-				//messageClass._stream << "Done: " << msg;
+                messageClass._stream << msg;
+                //messageClass._stream << "Done: " << msg;
 
-				if (_show_timing)
-					messageClass._stream << " (" << activity._timer.time () << " s)" << std::endl;
-				else
-					messageClass._stream << std::endl;
-			}
+                if (_show_timing)
+                    messageClass._stream << " (" << activity._timer.time () << " s)" << std::endl;
+                else
+                    messageClass._stream << std::endl;
+            }
 
-			messageClass._smart_streambuf.stream ().flush ();
-		}
-		else if (_format == OUTPUT_PIPE) {
-			for (i = 0; i < _activities.size (); ++i)
-				messageClass._stream << "  ";
+            messageClass._smart_streambuf.stream ().flush ();
+        }
+        else if (_format == OUTPUT_PIPE) {
+            for (i = 0; i < _activities.size (); ++i)
+                messageClass._stream << "  ";
 
-			if (((_show_progress || _show_est_time) && activity._len > 0) ||
-			    messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn))
-				messageClass._stream << "Done: " << msg << std::endl;
-			else
-				messageClass._stream << activity._desc << ": " << msg << std::endl;
-		}
-	}
+            if (((_show_progress || _show_est_time) && activity._len > 0) ||
+                messageClass.isPrinted (_activities.size () + 1, LEVEL_IMPORTANT, activity._fn))
+                messageClass._stream << "Done: " << msg << std::endl;
+            else
+                messageClass._stream << activity._desc << ": " << msg << std::endl;
+        }
+    }
 
-	MessageClass::MessageClass (const Commentator &comm,
-				    const char *msg_class,
-				    std::ostream &stream,
-				    unsigned long max_depth,
-				    unsigned long max_level) :
-		_msg_class (msg_class),
-		_smart_streambuf (comm, stream),
-		_stream (&_smart_streambuf),
-		_max_level (max_level),
-		_max_depth (max_depth)
-	{
-		fixDefaultConfig ();
-	}
+    MessageClass::MessageClass (const Commentator &comm,
+                                const char *msg_class,
+                                std::ostream &stream,
+                                unsigned long max_depth,
+                                unsigned long max_level) :
+        _msg_class (msg_class),
+        _smart_streambuf (comm, stream),
+        _stream (&_smart_streambuf),
+        _max_level (max_level),
+        _max_depth (max_depth)
+    {
+        fixDefaultConfig ();
+    }
 
-	void MessageClass::setMaxDepth (long depth)
-	{
-		_max_depth = (unsigned long) depth;
-		fixDefaultConfig ();
-	}
+    void MessageClass::setMaxDepth (long depth)
+    {
+        _max_depth = (unsigned long) depth;
+        fixDefaultConfig ();
+    }
 
-	void MessageClass::setMaxDetailLevel (long level)
-	{
-		_max_level = (unsigned long) level;
-		fixDefaultConfig ();
-	}
+    void MessageClass::setMaxDetailLevel (long level)
+    {
+        _max_level = (unsigned long) level;
+        fixDefaultConfig ();
+    }
 
-	void MessageClass::setPrintParameters (unsigned long depth, unsigned long level, const char *fn)
-	{
-		if (fn == (const char *) 0)
-			fn = "";
+    void MessageClass::setPrintParameters (unsigned long depth, unsigned long level, const char *fn)
+    {
+        if (fn == (const char *) 0)
+            fn = "";
 
-		std::list <std::pair <unsigned long, unsigned long> > &config = _configuration[fn];
-		std::list <std::pair <unsigned long, unsigned long> >::iterator i, j;
+        std::list <std::pair <unsigned long, unsigned long> > &config = _configuration[fn];
+        std::list <std::pair <unsigned long, unsigned long> >::iterator i, j;
 
-		i = config.begin ();
+        i = config.begin ();
 
-		// Iterate through preceeding elements in the std::list and remove
-		// any that specify a lower level than we are using
-		while (i != config.end () && i->first <= depth) {
-			if (i->second <= level) {
-				j = i++;
-				config.erase (j);
-			}
-			else {
-				++i;
-			}
-		}
+        // Iterate through preceeding elements in the std::list and remove
+        // any that specify a lower level than we are using
+        while (i != config.end () && i->first <= depth) {
+            if (i->second <= level) {
+                j = i++;
+                config.erase (j);
+            }
+            else {
+                ++i;
+            }
+        }
 
-		// Insert our new directive into the std::list
-		if (i == config.end () || i->second != level)
-			config.insert (i, std::pair <unsigned long, unsigned long> (depth, level));
+        // Insert our new directive into the std::list
+        if (i == config.end () || i->second != level)
+            config.insert (i, std::pair <unsigned long, unsigned long> (depth, level));
 
-		// Iterate through following elements in the std::list and remove any
-		// that specify a higher level than we are using
-		while (i != config.end ()) {
-			if (i->second > level) {
-				j = i++;
-				config.erase (j);
-			}
-			else {
-				++i;
-			}
-		}
+        // Iterate through following elements in the std::list and remove any
+        // that specify a higher level than we are using
+        while (i != config.end ()) {
+            if (i->second > level) {
+                j = i++;
+                config.erase (j);
+            }
+            else {
+                ++i;
+            }
+        }
 
-		// End result: The std::list should be monotonically increasing in
-		// the first parameter and decreasing in the second
-	}
+        // End result: The std::list should be monotonically increasing in
+        // the first parameter and decreasing in the second
+    }
 
-	bool MessageClass::isPrinted (unsigned long depth, unsigned long level, const char *fn)
-	{
-		return
-		checkConfig (_configuration[""], depth, level)
-		||
-		(	fn != (const char *) 0
-			&&
-			checkConfig (_configuration[fn], depth, level)
-		);
+    bool MessageClass::isPrinted (unsigned long depth, unsigned long level, const char *fn)
+    {
+        return
+        checkConfig (_configuration[""], depth, level)
+        ||
+        (	fn != (const char *) 0
+            &&
+            checkConfig (_configuration[fn], depth, level)
+        );
 #if 0
 
-		if (checkConfig (_configuration[""], depth, level))
-			return true;
-		else if (fn != (const char *) 0)
-			//return checkConfig (_configuration[fn], depth, level);
-		{ bool ans = checkConfig (_configuration[fn], depth, level);
-			if (ans)
-			{	//std::cerr << " fn=" << fn << ", d " << depth << ", l " << level << " true" << std::endl;
-				return true;
-			}
-			else
-			{	//std::cerr << " fn=" << fn << ", d " << depth << ", l " << level << " false" << std::endl;
-				return false;
-			}
-		}
+        if (checkConfig (_configuration[""], depth, level))
+            return true;
+        else if (fn != (const char *) 0)
+            //return checkConfig (_configuration[fn], depth, level);
+        { bool ans = checkConfig (_configuration[fn], depth, level);
+            if (ans)
+            {	//std::cerr << " fn=" << fn << ", d " << depth << ", l " << level << " true" << std::endl;
+                return true;
+            }
+            else
+            {	//std::cerr << " fn=" << fn << ", d " << depth << ", l " << level << " false" << std::endl;
+                return false;
+            }
+        }
 
-		else
-		{	//std::cerr << " fn=0, d " << depth << ", l " << level << " false" << std::endl;
-			return false;
-		}
+        else
+        {	//std::cerr << " fn=0, d " << depth << ", l " << level << " false" << std::endl;
+            return false;
+        }
 
 #endif
-	}
+    }
 
-	MessageClass::MessageClass (const Commentator &comm,
-				    const char *msg_class,
-				    std::ostream &stream,
-				    Configuration configuration) :
-		_msg_class (msg_class),
-		_smart_streambuf (comm, stream),
-		_stream (&_smart_streambuf),
-		_configuration (configuration)
-	{}
+    MessageClass::MessageClass (const Commentator &comm,
+                                const char *msg_class,
+                                std::ostream &stream,
+                                Configuration configuration) :
+        _msg_class (msg_class),
+        _smart_streambuf (comm, stream),
+        _stream (&_smart_streambuf),
+        _configuration (configuration)
+    {}
 
-	void MessageClass::fixDefaultConfig ()
-	{
-		std::list <std::pair <unsigned long, unsigned long> > &config = _configuration[""];
+    void MessageClass::fixDefaultConfig ()
+    {
+        std::list <std::pair <unsigned long, unsigned long> > &config = _configuration[""];
 
-		config.clear ();
-		config.push_back (std::pair <unsigned long, unsigned long> (_max_depth, _max_level));
-		config.push_back (std::pair <unsigned long, unsigned long> ((unsigned long) -1, Commentator::LEVEL_ALWAYS));
-	}
+        config.clear ();
+        config.push_back (std::pair <unsigned long, unsigned long> (_max_depth, _max_level));
+        config.push_back (std::pair <unsigned long, unsigned long> ((unsigned long) -1, Commentator::LEVEL_ALWAYS));
+    }
 
-	bool MessageClass::checkConfig (std::list <std::pair <unsigned long, unsigned long> > &config,
-					unsigned long depth,
-					unsigned long ) //lvl
-	{
-		std::list <std::pair <unsigned long, unsigned long> >::iterator i;
+    bool MessageClass::checkConfig (std::list <std::pair <unsigned long, unsigned long> > &config,
+                                    unsigned long depth,
+                                    unsigned long ) //lvl
+    {
+        std::list <std::pair <unsigned long, unsigned long> >::iterator i;
 
-		for ( i = config.begin (); i != config.end (); ++i) {
-			if (depth < i->first) {
+        for ( i = config.begin (); i != config.end (); ++i) {
+            if (depth < i->first) {
 #if 0
-				// uninitialized value error goes away if we ignore level.
-				if (level <= i->second)
-					return true;
-				else
-					return false;
+                // uninitialized value error goes away if we ignore level.
+                if (level <= i->second)
+                    return true;
+                else
+                    return false;
 #endif
-				return true;
-			}
-		}
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	void MessageClass::dumpConfig () const
-	{
-		Configuration::const_iterator i;
-		std::list <std::pair <unsigned long, unsigned long> >::const_iterator j;
+    void MessageClass::dumpConfig () const
+    {
+        Configuration::const_iterator i;
+        std::list <std::pair <unsigned long, unsigned long> >::const_iterator j;
 
-		for (i = _configuration.begin (); i != _configuration.end (); ++i) {
-			std::cerr << "Configuration (" << (*i).first << "):" << std::endl;
+        for (i = _configuration.begin (); i != _configuration.end (); ++i) {
+            std::cerr << "Configuration (" << (*i).first << "):" << std::endl;
 
-			for (j = (*i).second.begin (); j != (*i).second.end (); ++j)
-				std::cerr << "  Depth: " << (*j).first << ", Level: " << (*j).second << std::endl;
+            for (j = (*i).second.begin (); j != (*i).second.end (); ++j)
+                std::cerr << "  Depth: " << (*j).first << ", Level: " << (*j).second << std::endl;
 
-			std::cerr << std::endl;
-		}
-	}
+            std::cerr << std::endl;
+        }
+    }
 
-	int MessageClass::smartStreambuf::sync ()
-	{
-		std::streamsize n = pptr () - pbase ();
-		return (n && writeData (pbase (), n) != n) ? EOF : 0;
-	}
+    int MessageClass::smartStreambuf::sync ()
+    {
+        std::streamsize n = pptr () - pbase ();
+        return (n && writeData (pbase (), n) != n) ? EOF : 0;
+    }
 
-	int MessageClass::smartStreambuf::overflow (int ch)
-	{
-		std::streamsize n = pptr () - pbase ();
+    int MessageClass::smartStreambuf::overflow (int ch)
+    {
+        std::streamsize n = pptr () - pbase ();
 
-		if (n && sync ())
-			return EOF;
+        if (n && sync ())
+            return EOF;
 
-		if (ch != EOF) {
-			char cbuf[1];
-			cbuf[0] = (char)ch;
-			if (writeData (cbuf, 1) != 1)
-				return EOF;
-		}
+        if (ch != EOF) {
+            char cbuf[1];
+            cbuf[0] = (char)ch;
+            if (writeData (cbuf, 1) != 1)
+                return EOF;
+        }
 
-		pbump((int)-n);
-		return 0;
-	}
+        pbump((int)-n);
+        return 0;
+    }
 
-	std::streamsize MessageClass::smartStreambuf::xsputn (const char *text, std::streamsize n)
-	{
-		return (sync () == EOF) ? 0 : writeData (text, n);
-	}
+    std::streamsize MessageClass::smartStreambuf::xsputn (const char *text, std::streamsize n)
+    {
+        return (sync () == EOF) ? 0 : writeData (text, n);
+    }
 
-	int MessageClass::smartStreambuf::writeData (const char *text, std::streamsize n)
-	{
-		std::streamsize idx;
-		std::streamsize m = n;
+    int MessageClass::smartStreambuf::writeData (const char *text, std::streamsize n)
+    {
+        std::streamsize idx;
+        std::streamsize m = n;
 
-		if (_indent_next) {
-			_comm.indent (_stream);
-			_indent_next = false;
-		}
+        if (_indent_next) {
+            _comm.indent (_stream);
+            _indent_next = false;
+        }
 
-		for (idx = 0; (idx < m) &&(text[idx] != '\n') ; ++idx) ;
+        for (idx = 0; (idx < m) &&(text[idx] != '\n') ; ++idx) ;
 
-		while (idx < m) {
-			_stream.write (text, idx + 1);
-			m -= idx + 1;
+        while (idx < m) {
+            _stream.write (text, idx + 1);
+            m -= idx + 1;
 
-			if (m > 0)
-				_comm.indent (_stream);
-			else
-				_indent_next = true;
+            if (m > 0)
+                _comm.indent (_stream);
+            else
+                _indent_next = true;
 
-			text += idx + 1;
-			for (idx = 0; idx != '\n' && idx < m; ++idx) ;
-		}
+            text += idx + 1;
+            for (idx = 0; idx != '\n' && idx < m; ++idx) ;
+        }
 
-		_stream.write (text, m);
+        _stream.write (text, m);
 
-		_stream.flush ();
+        _stream.flush ();
 
-		return int(n);
-	}
+        return int(n);
+    }
 
-// 	// Default global commentator
-// 	Commentator commentator ;
+    // 	// Default global commentator
+    // 	Commentator commentator ;
 }
 
 // Local Variables:


### PR DESCRIPTION
`valgrind` was complaining because `cnull` initialization called open on `0`. Fixed by initializing `cnull` with `/dev/null`. 

Also fixes the indentation in a different commit, replacing tabs by spaces according to the descriptions at the end of the files.