### PR TITLE
Clean some check functions

### DIFF
--- a/linbox/integer.h
+++ b/linbox/integer.h
@@ -144,13 +144,13 @@ namespace LinBox { /*  signedness of integers */
     }
 
 	template<typename IntType>
-	bool isOdd (const IntType& value)
+	inline bool isOdd (const IntType& value)
 	{
 		return value & IntType(1);
 	}
 
 	template<typename IntType>
-	bool isEven (const IntType& p)
+	inline bool isEven (const IntType& p)
 	{
 		return !isOdd(p);
 	}

--- a/linbox/integer.h
+++ b/linbox/integer.h
@@ -175,16 +175,16 @@ namespace LinBox { /*  signedness of integers */
 		return false;
 	}
 
-	template<class T>
-	bool isOdd ( const T & p)
+	template<typename IntType>
+	bool isOdd (const IntType& value)
 	{
-		return Givaro::isOdd(p) ;
+		return value & IntType(1);
 	}
 
-	template<class T>
-	bool isEven ( const T & p)
+	template<typename IntType>
+	bool isEven (const IntType& p)
 	{
-		return ! isOdd(p) ;
+		return !isOdd(p);
 	}
 
 }

--- a/linbox/integer.h
+++ b/linbox/integer.h
@@ -116,64 +116,32 @@ namespace LinBox { /*  signedness of integers */
 	 * @return \c true iff \c x>=0.
 	 */
 	//@{
-	template<class T>
-	inline bool isPositive( const T & x) {
-		return x>=0 ;
-	}
-	template<>
-	inline bool isPositive(const uint8_t &) {
-		return true ;
-	}
-	template<>
-	inline bool isPositive(const uint16_t &) {
-		return true ;
-	}
-	template<>
-	inline bool isPositive(const uint32_t &) {
-		return true ;
-	}
-#ifdef __APPLE__
-	template<>
-	inline bool isPositive(const unsigned long&) {
-		return true ;
-	}
-#endif
-	template<>
-	inline bool isPositive(const uint64_t &) {
-		return true ;
-	}
-	//@}
+    //
 
-	template<class U>
-	inline bool IsNegative(const U & p)
-	{
-		return (!isPositive<U>(p));
-	}
 
-	//! @todo or use integer_traits<T>::is_unsigned ??
-	template<>
-	inline bool IsNegative(const uint8_t & p)
-	{
-		return false;
-	}
+    template< class T>
+    inline typename std::enable_if<!std::is_unsigned<T>::value, bool>::value
+    isPositive (const T& t) {
+        return t >= 0;
+    }
 
-	template<>
-	inline bool IsNegative(const uint16_t & p)
-	{
-		return false;
-	}
+    template< class T>
+    inline typename std::enable_if<std::is_unsigned<T>::value, bool>::value
+    isPositive (const T& t) {
+        return true;
+    }
 
-	template<>
-	inline bool IsNegative(const uint32_t & p)
-	{
-		return false;
-	}
+    template<class T>
+    inline typename std::enable_if<!std::is_unsigned<T>::value, bool>::value
+    isNegative (const T& t) {
+        return (!isPositive<T>(t));
+    }
 
-	template<>
-	inline bool IsNegative(const uint64_t & p)
-	{
-		return false;
-	}
+    template<class T>
+    inline typename std::enable_if<std::is_unsigned<T>::value, bool>::value
+    isNegative (const T& t) {
+        return false;
+    }
 
 	template<typename IntType>
 	bool isOdd (const IntType& value)


### PR DESCRIPTION
This PR cleans some check functions, namely `isOdd/Even` and `isPositive/Negative`.
It reduces the number of override functions for checking positivity, renames all in `isX` (instead of `isX` or `IsX`) and removes dependency on  Givaro check functions.
See Issue #137 for original comments.