### PR TITLE
Remove @LINBOXSAGE_LIBS@ from linbox.pc.in

### DIFF
--- a/linbox.pc.in
+++ b/linbox.pc.in
@@ -9,6 +9,6 @@ Description: Exact Linear Algebra library
 URL: http://github.com/linbox-team/linbox
 Version: @VERSION@
 Requires: fflas-ffpack >= 2.3.1, givaro >= 4.0.5
-Libs: -L${libdir} -llinbox @LINBOXSAGE_LIBS@ @NTL_LIBS@ @MPFR_LIBS@ @FPLLL_LIBS@ @IML_LIBS@ @FLINT_LIBS@ @OCL_LIBS@
+Libs: -L${libdir} -llinbox @NTL_LIBS@ @MPFR_LIBS@ @FPLLL_LIBS@ @IML_LIBS@ @FLINT_LIBS@ @OCL_LIBS@
 Cflags: @DEFAULT_CFLAGS@ -DDISABLE_COMMENTATOR -I${includedir} @NTL_CFLAGS@ @MPFR_CFLAGS@ @FPLLL_CFLAGS@  @IML_CFLAGS@ @FLINT_CFLAGS@ 
 \-------------------------------------------------------


### PR DESCRIPTION
In the file `linbox.pc.in`, the placeholder `@LINBOXSAGE_LIBS@` was never substituted preventing the use of `pkg-config --libs linbox` for compiling code using LinBox.
As `git grep LINBOXSAGE` returns nothing, I assume it is a remaining artifact from some old and removed code and can be safely removed.