### PR TITLE
Fixing #175: RandomFFTPrime

### DIFF
--- a/benchmarks/benchmark-order-basis.C
+++ b/benchmarks/benchmark-order-basis.C
@@ -375,8 +375,10 @@ int main(int argc, char** argv){
 			std::cout<<"degree is to large for field bitsize: "<<b<<std::endl;
 			exit(0);
 		}
-		RandomFFTPrime Rd(1<<b,seed);
-		integer p = Rd.randomPrime(logd+1);
+        integer p;
+		RandomFFTPrime::seeding (seed);
+		if (!RandomFFTPrime::randomPrime (p, 1<<b, logd+1))
+			throw LinboxError ("RandomFFTPrime::randomPrime failed");
 		std::cout<<"# starting sigma basis computation over Fp[x] with p="<<p<<endl;;		
 		SmallField F(p);
 		typename SmallField::RandIter G(F,0,seed);

--- a/examples/bench-fft.C
+++ b/examples/bench-fft.C
@@ -238,8 +238,11 @@ int main(int argc, char** argv){
 	}
 	uint64_t bits =atoi(argv[1]);
 	long seed=((argc>2)?atoi(argv[2]):time(NULL));	
-	RandomFFTPrime Rd(1<<bits,seed);
-	uint32_t p = (uint32_t)Rd.randomPrime(5);
+	integer prime;
+	RandomFFTPrime::seeding (seed);
+	if (!RandomFFTPrime::randomPrime (prime, 1<<bits, 5))
+		throw LinboxError ("RandomFFTPrime::randomPrime failed");
+	uint32_t p = (uint32_t) prime;
 	size_t k = bits-4;
 	cout<<"prime : "<<p<<endl;
 	cout<<endl;

--- a/examples/bench-matpoly-mult.C
+++ b/examples/bench-matpoly-mult.C
@@ -511,8 +511,11 @@ int main(int argc, char** argv){
 			FFT_PROF_LEVEL=1; 
 #endif
 			if (fourier){
-				RandomFFTPrime Rd(1<<b,seed);
-				integer p = Rd.randomPrime(integer(d).bitsize()+1);
+				integer p;
+				RandomFFTPrime::seeding (seed);
+				if (!RandomFFTPrime::randomPrime (p, 1<<b, integer(d).bitsize()+1))
+					throw LinboxError ("RandomFFTPrime::randomPrime failed");
+
 				//Givaro::Modular<int32_t> F((int32_t)p);
 				Givaro::Modular<double> F((int32_t)p);
 				cout<<"Computation over Fp[x] with p=  "<<p<<" (FFT prime)"<<endl;

--- a/examples/bench-new-fft.C
+++ b/examples/bench-new-fft.C
@@ -263,9 +263,8 @@ int main(int argc, char** argv){
 	long seed=((argc>2)?atoi(argv[2]):time(NULL));
 	size_t l2n = 20;
 	size_t k = l2n;
-	RandomFFTPrime Rd;
 	uint32_t p;
-
+    integer prime;
 
 	//Modular<double,double>
 	
@@ -295,8 +294,10 @@ int main(int argc, char** argv){
 	*/
 	//Modular<uint32_t,uint64_t>
 	bits = 27;
-	Rd = RandomFFTPrime (1<<bits,seed);
-	p = (uint32_t)Rd.randomPrime(l2n);
+	RandomFFTPrime::seeding (seed);
+	if (!RandomFFTPrime::randomPrime (prime, 1<<bits, l2n))
+		throw LinboxError ("RandomFFTPrime::randomPrime failed");
+	p = (uint32_t) prime;
 
 	Givaro::Modular<uint32_t,uint64_t> Fi32(p);
 	Fi32.write(cout)<<endl;
@@ -308,8 +309,9 @@ int main(int argc, char** argv){
 	//Modular<uint16_t,uint32_t>
 	bits = 11;
 	k = l2n = 7;
-	Rd = RandomFFTPrime (1<<bits,seed);
-	p = (uint16_t)Rd.randomPrime(l2n);
+	if (!RandomFFTPrime::randomPrime (prime, 1<<bits, l2n))
+		throw LinboxError ("RandomFFTPrime::randomPrime failed");
+	p = (uint16_t) prime;
 	
 
 	Givaro::Modular<uint16_t,uint32_t> Fi16(p);

--- a/linbox/algorithms/matpoly-mult.h
+++ b/linbox/algorithms/matpoly-mult.h
@@ -523,18 +523,14 @@ namespace LinBox
 
 				// get number of necessary primes
 				integer ibound = uint64_t(n) * _p * _p * uint64_t(std::max(b.size(), c.size()));
-				integer primesprod;
-				size_t nbrprimes=1;
-				RandomFFTPrime fftprime(bit, FFT_PRIME_SEED);
-				std::vector<integer> lprimes(10); lprimes.resize(nbrprimes);
-				lprimes[0] = fftprime.generatePrime();
-				primesprod = lprimes[0];
-				while (primesprod < ibound) {
-					++nbrprimes;
-					lprimes.resize(nbrprimes);
-					do {lprimes[nbrprimes-1] = fftprime.generatePrime();} while (primesprod % lprimes[nbrprimes-1] == 0);
-					primesprod *= lprimes[nbrprimes-1];
-				}
+				std::vector<integer> lprimes;
+				RandomFFTPrime::seeding (FFT_PRIME_SEED);
+				if (!RandomFFTPrime::generatePrimes (lprimes, bit, ibound))
+					throw LinboxError ("RandomFFTPrime::generatePrime failed");
+				size_t nbrprimes = lprimes.size();
+				integer primesprod = 1;
+				for (auto &p: lprimes)
+					primesprod *= p;
 #ifdef FFT_TIMING
 				std::cout<<"num of primes "<<nbrprimes<< std::endl;
 #endif
@@ -639,19 +635,14 @@ namespace LinBox
 
 				// get number of necessary primes
 				integer ibound = uint64_t(n) * _p * _p * uint64_t(std::max(b.size(), c.size()));
-				integer primesprod;
-				size_t nbrprimes=1;
-				RandomFFTPrime fftprime(bit, FFT_PRIME_SEED);
-				std::vector<integer> lprimes(10); lprimes.resize(nbrprimes);
-				lprimes[0] = fftprime.generatePrime();
-				primesprod = lprimes[0];
-				while (primesprod < ibound) {
-					++nbrprimes;
-					lprimes.resize(nbrprimes);
-					do {lprimes[nbrprimes-1] = fftprime.generatePrime();} while (primesprod % lprimes[nbrprimes-1] == 0);
-					primesprod *= lprimes[nbrprimes-1];
-				}
-
+				std::vector<integer> lprimes;
+				RandomFFTPrime::seeding (FFT_PRIME_SEED);
+				if (!RandomFFTPrime::generatePrimes (lprimes, bit, ibound))
+					throw LinboxError ("RandomFFTPrime::generatePrime failed");
+				size_t nbrprimes = lprimes.size();
+				integer primesprod = 1;
+				for (auto &p: lprimes)
+					primesprod *= p;
 #ifdef FFT_TIMING
 				std::cout<<"num of primes "<<nbrprimes<<"\n";
 #endif
@@ -777,17 +768,14 @@ namespace LinBox
 
 			// get number of necessary primes
 			integer ibound = n * _p * _p * std::max(b.size(), c.size());
-			integer primesprod=1; size_t nbrprimes=1;
-			RandomFFTPrime fftprime(bit, FFT_PRIME_SEED);
-			std::vector<integer> lprimes(10); lprimes.resize(nbrprimes);
-			lprimes[0] = fftprime.generatePrime();
-			primesprod = lprimes[0];
-			while (primesprod < ibound) {
-				++nbrprimes;
-				lprimes.resize(nbrprimes);
-				do {lprimes[nbrprimes-1] = fftprime.generatePrime();} while (primesprod % lprimes[nbrprimes-1] == 0);
-				primesprod *= lprimes[nbrprimes-1];
-			}
+			std::vector<integer> lprimes;
+			RandomFFTPrime::seeding (FFT_PRIME_SEED);
+			if (!RandomFFTPrime::generatePrimes (lprimes, bit, ibound))
+				throw LinboxError ("RandomFFTPrime::generatePrime failed");
+			size_t nbrprimes = lprimes.size();
+			integer primesprod = 1;
+			for (auto &p: lprimes)
+				primesprod *= p;
 #ifdef FFT_TIMING
 			std::cout<<"num of primes "<<nbrprimes<<"\n";
 #endif
@@ -894,18 +882,14 @@ namespace LinBox
 
 				// get number of necessary primes
 				integer ibound = n * _p * _p * std::max(b.size(), c.size());
-				integer primesprod=1; size_t nbrprimes=1;
-				RandomFFTPrime fftprime(bit, FFT_PRIME_SEED);
-				std::vector<integer> lprimes(10); lprimes.resize(nbrprimes);
-				lprimes[0] = fftprime.generatePrime();
-				primesprod = lprimes[0];
-				while (primesprod < ibound) {
-					++nbrprimes;
-					lprimes.resize(nbrprimes);
-					do {lprimes[nbrprimes-1] = fftprime.generatePrime();} while (primesprod % lprimes[nbrprimes-1] == 0);
-					primesprod *= lprimes[nbrprimes-1];
-				}
-
+				std::vector<integer> lprimes;
+				RandomFFTPrime::seeding (FFT_PRIME_SEED);
+				if (!RandomFFTPrime::generatePrimes (lprimes, bit, ibound))
+					throw LinboxError ("RandomFFTPrime::generatePrime failed");
+				size_t nbrprimes = lprimes.size();
+				integer primesprod = 1;
+				for (auto &p: lprimes)
+					primesprod *= p;
 #ifdef FFT_TIMING
 				std::cout<<"num of primes "<<nbrprimes<<"\n";
 #endif

--- a/linbox/algorithms/polynomial-matrix/matpoly-mult-fft-wordsize-three-primes.inl
+++ b/linbox/algorithms/polynomial-matrix/matpoly-mult-fft-wordsize-three-primes.inl
@@ -119,9 +119,8 @@ namespace LinBox {
 			size_t k = a.coldim();
 			size_t n = b.coldim();
 			uint64_t prime_max=maxFFTPrimeValue(k,pts); // CAREFUL: only for Modular<double>;
-			RandomFFTPrime RdFFT(prime_max);
 			std::vector<integer> bas;
-			if (!RdFFT.generatePrimes(lpts,bound,bas)){
+			if (!RandomFFTPrime::generatePrimes (bas, prime_max, bound, lpts)){
 				std::cout<<"COULD NOT FIND ENOUGH FFT PRIME in MatPoly 3-Primes FFT MUL exiting..."<<std::endl;
 				std::cout<<"Parameters : ("<<m<<"x"<<k<<") ("<<k<<"x"<<n<<") with "<<pts<<" points with prime= "<<_p<<std::endl; 
 				throw LinboxError("LinBox ERROR: not enough FFT Prime\n");
@@ -257,12 +256,8 @@ namespace LinBox {
 			//uint64_t prime_max= std::min(uint64_t(std::sqrt( (1ULL<<53) / k)+1), uint64_t(Givaro::Modular<double>::maxCardinality())) 
 			uint64_t prime_max=maxFFTPrimeValue(k,pts); // CAREFUL: only for Modular<double>;
 			
-			RandomFFTPrime RdFFT(prime_max);
-
 			std::vector<integer> bas;
-
-			
-			if (!RdFFT.generatePrimes(lpts,bound,bas)){
+			if (!RandomFFTPrime::generatePrimes (bas, prime_max, bound, lpts)){
 				std::cout<<"COULD NOT FIND ENOUGH FFT PRIME  in MatPoly 3-Primes FFT MIDP exiting..."<<std::endl;
 				std::cout<<"Parameters : ("<<m<<"x"<<k<<") ("<<k<<"x"<<n<<") with "<<pts<<" points with prime= "<<_p<<std::endl; 
 				throw LinboxError("LinBox ERROR: not enough FFT Prime\n");

--- a/linbox/algorithms/polynomial-matrix/matpoly-mult-fft.h
+++ b/linbox/algorithms/polynomial-matrix/matpoly-mult-fft.h
@@ -327,11 +327,9 @@ namespace LinBox
   }
 
   void getFFTPrime(uint64_t prime_max, size_t lpts, integer bound, std::vector<integer> &bas, size_t k, size_t d){
-	  
-    RandomFFTPrime RdFFT(prime_max);
-    size_t nbp=0;
-	  
-    if (!RdFFT.generatePrimes(lpts,bound,bas)){ // not enough FFT prime found 
+	size_t nbp=0;
+	bool b = RandomFFTPrime::generatePrimes (bas, prime_max, bound, lpts);
+	if (!b){ /* not enough FFT prime found */
       integer MM=1;
       for(std::vector<integer>::size_type i=0;i<bas.size();i++){
 	MM*=bas[i];

--- a/linbox/randiter/random-fftprime.h
+++ b/linbox/randiter/random-fftprime.h
@@ -32,206 +32,137 @@
 
 namespace LinBox
 {
-
 	class RandomFFTPrime {
 	public:
-		// define the prime type
-		typedef integer Prime_Type;
+		typedef integer PrimeType; /* define the prime type */
+		typedef std::vector<PrimeType> VectPrime;
+		static const int32_t probab_prime_ntests = 25;
+		static const size_t max_ntries = 256;
 
-		uint64_t           _bits;
-		Prime_Type  _prime_bound;
-
-		RandomFFTPrime(Prime_Type pbound=0x100000, unsigned long seed = 0) :
-			_bits(pbound.bitsize()), _prime_bound(pbound)
-		{
-			if (! seed)
-				RandomFFTPrime::setSeed( (unsigned long)BaseTimer::seed() );
-			else
-				RandomFFTPrime::setSeed( seed );
-		}
-
-		
-		/** @brief randomPrime(size_t b)
-		 *  return a random FFT prime with a 2-valuation larger than b in its order
-				 *  the randomness is on the FFT primes lying in the given range
-				 *  an error is thrown if no such prime exist
+		/* Set p to an odd random prime such that
+		 *  - p < pbound
+		 *  - 2^k divides p-1
+		 *
+		 * The function repeatedly draws a random positive integer m and check
+		 * if m*2^k+1 is prime, using Givaro::Protected::probab_prime.
+		 *
+		 * If after max_ntries tries, the function fails to find a prime, it
+		 * returns false and p is set to 0.
 		 */
-		inline Prime_Type randomPrime (size_t b) const
+		static inline bool randomPrime (PrimeType &p, const PrimeType &pbound, size_t k)
 		{
-			integer tmp;
-			randomPrime(tmp,b);
-			return tmp;
-		}
-
-		/** @brief randomPrime(Prime_Type& p, size_t b)
-		 *  return a random FFT prime with a 2-valuation larger than b in its order
-				 *  the randomness is on the FFT primes lying in the given range
-				 *  an error is thrown if no such prime exist
-		 */
-		inline Prime_Type randomPrime (Prime_Type& t, uint64_t b) const
-		{
-			linbox_check(b<_bits);
-			size_t tresh;
-			do {
-				size_t cbits= (size_t)rand() %(_bits-b);
-				tresh = 1<<(cbits);
-				uint64_t p = 1<<((size_t)_bits-cbits);
-				do {
-					integer::random(t,cbits);
-					t = t*integer(p)+1;
-					tresh--;
-				} while (!Givaro::Protected::probab_prime(t,25) && (tresh));
-			}
-			while(tresh==0);
-			linbox_check(Givaro::Protected::probab_prime(t,25))
-					return t;
-		}
-
-		/** @brief generatePrime()
-		 *  return a FFT prime with the largest 2-valuation in its order
-		 */
-		inline Prime_Type generatePrime() const
-		{
-			integer tmp;
-			generatePrime(tmp);
-			return tmp;
-		}
-
-		/** @brief generatePrime(Prime_Type& p)
-		 *  return a FFT prime with the largest 2-valuation in its order
-		 */
-		inline Prime_Type generatePrime (Prime_Type& t) const
-		{
-			size_t cbits=1;
-			size_t tresh;
-			do {
-				tresh = 1<<(cbits);
-				uint64_t p = 1<<((size_t)_bits-cbits);
-				do {
-					integer::random(t,cbits);
-					t = t*integer(p)+1;
-					tresh--;
-				} while (!Givaro::Protected::probab_prime(t,25) && (tresh));
-				cbits++;
-			}
-			while(tresh==0);
-
-			return t;
-		}
-
-		// generate a vector of distinct FFT primes with largest 2-valuation
-		// s.t. their product is larger than a given bound
-		inline std::vector<Prime_Type> generatePrimes (const Prime_Type & bound) const {
-			std::vector<Prime_Type> primes;
-			Prime_Type prod=1;
-			integer tmp;
-			for (int64_t b = _bits - 1; b >= 0; b--)
-				for (int64_t l = ((int64_t)1 << (_bits - b - 1)) + 1; l < (1L << (_bits - b)); l +=2) {
-					tmp = ((int64_t)1 << b) * l + 1;
-					if (Givaro::Protected::probab_prime(tmp, 25) >= 1) {
-						primes.push_back(tmp);
-						prod*=tmp;
-						if (prod > bound)
-							return primes;
-					}
-				}
-			linbox_check(prod > bound ); // Could not find enough primes
-			return primes;
-		}
-
-		// generate a vector of distinct FFT primes with largest 2-valuation
-		// s.t. their product is larger than a given bound
-		inline bool generatePrimes (const Prime_Type & bound, std::vector<Prime_Type> &primes) const {
-			primes.clear();
-			Prime_Type prod=1;
-			integer tmp;
-			for (int64_t b = (int64_t)_bits - 1; b >= 0; b--)
-				for (int64_t l = (1L << ((int64_t)_bits - b - 1)) + 1; l < (1L << ((int64_t)_bits - b)); l +=2) {
-					tmp = (1L << b) * l + 1;
-					if (Givaro::Protected::probab_prime(tmp, 25) >= 1) {
-						primes.push_back(tmp);
-						prod*=tmp;
-						if (prod > bound){
-							return true;
-						}
-					}
-				}
-			return false; // false -> Could not find enough primes
-		}
-
-		size_t twoVal(integer t) const {
-			integer x=t;
-			size_t v=0;
-			while(x%2 == 0) {v++;x/=2;}
-			return v;
-		}
-
-		// generate a vector of distinct FFT primes with  2-valuation largest than val
-		// s.t. their product is larger than a given bound
-		inline bool generatePrimes ( uint64_t val, const Prime_Type & bound, std::vector<Prime_Type> &primes) const {
-			primes.clear();
-			Prime_Type prod=1;
-			integer tmp;
-			// std::cout<<"rns bound: "<<bound<<std::endl;
-			// std::cout<<"2 valuation: "<<val<<std::endl;
-			// std::cout<<"prime bitmax: "<<_bits<<std::endl;
-			// std::cout<<"prime max: "<<_prime_bound<<std::endl;
-
-			if (val > _bits) return false;
-
-#if 0
-			for (int64_t b = (int64_t)_bits; b >= (int64_t)val; b--)
-				// for (uint64_t l = (1ULL << ((int64_t)_bits - b - 1)) + 1; l < (1ULL << ((int64_t)_bits - b)); l +=2) {
-				for (int64_t l = ((int64_t)1 << ((int64_t)_bits - b)) - 1; l >=1; l -=2) {
-					tmp = ((int64_t)1 << b) * l + 1;
-					if (Givaro::Protected::probab_prime(tmp, 25) >= 1) {
-						primes.push_back(tmp);
-						prod*=tmp;
-						//std::cout<<tmp<<" -> "<<tmp.bitsize()<<" (order="<<twoVal(tmp-1)<<") "<<prod<<std::endl;
-						if (prod > bound){
-							return true;
-						}
-					}
-				}
-#else
-			for (int64_t l = (_prime_bound -1) >>val ; l >=1; l -=1) {
-				tmp = ((int64_t)1 << val) * l + 1;
-				if (Givaro::Protected::probab_prime(tmp, 25) >= 1) {
-					primes.push_back(tmp);
-					prod*=tmp;
-					//std::cout<<tmp<<" -> "<<tmp.bitsize()<<" (order="<<twoVal(tmp-1)<<") "<<prod<<std::endl;
-					if (prod > bound){
-						// try to replace the last prime with a smallest one
-						for (int64_t k=1;k<l;k++){
-							tmp = ((int64_t)1 << val) * k + 1;
-							if (Givaro::Protected::probab_prime(tmp, 25) >= 1) {
-								if (prod*tmp > bound*primes.back()){
-									//std::cout<<"replacing prime "<<primes.back()<<" with "<<tmp<< " -> "<<tmp.bitsize()<<" (order="<<twoVal(tmp-1)<<") ";
-									prod/=primes.back();
-									primes.back()=tmp;
-									prod*=tmp;
-									//std::cout<<prod<<std::endl;
-									return true;
-								}
-							}
-						}
-
+			using Givaro::Protected::probab_prime;
+			integer B = compute_max_m (pbound, k);
+			if (B > 0)
+			{
+				for (size_t ntries = 0; ntries < max_ntries; ntries++)
+				{
+					integer::random_lessthan (p, B); /* 0 <= p < B */
+					p = ((p+1) << k) + 1; /* 2^k+1 <= p < pbound */
+					if (probab_prime (p, probab_prime_ntests))
 						return true;
+				}
+			}
+			p = 0;
+			return false;
+		}
+
+		/* Set p to the largest odd prime satisfying
+		 *  - p < pbound
+		 *  - the 2-valuation of p-1 is maximal and >= kmin
+		 *
+		 * The function sets p to 0 and returns false, if there is no odd prime
+		 * below pbound.
+		 */
+		static inline bool generatePrime (PrimeType &p, const PrimeType &pbound, size_t kmin = 1)
+		{
+			using Givaro::Protected::probab_prime;
+			if (!kmin) /* set kmin to 1 if k == 0 */
+				kmin++;
+			for (size_t k = (pbound-2).bitsize()-1; k >= kmin; k--)
+			{
+				integer m = compute_max_m (pbound, k);
+				/* test only odd value of m, so k is exactly the 2-valuation */
+				if (!Givaro::isOdd (m))
+					m--;
+				for ( ; m > 0; m -= 2)
+				{
+					p = (m << k) + 1; /* p = m*2^k+1 */
+					if (probab_prime (p, probab_prime_ntests))
+						return true;
+				}
+			}
+			p = 0;
+			return false;
+		}
+
+		/* Set primes to a vector of distinct primes pi such that
+		 *  - pi < pbound
+		 *  - prod pi >= prodbound
+		 *  - the 2-valuation of pi-1 is >= kmin and as large as possible
+		 *
+		 * The function returns false if there is no enough primes. In this
+		 * case, the vector still contains the primes found so far.
+		 */
+		static inline bool generatePrimes (VectPrime &primes, const PrimeType &pbound, const PrimeType & prodbound, size_t kmin = 1)
+		{
+			using Givaro::Protected::probab_prime;
+			primes.clear();
+			PrimeType p, prod = 1;
+			if (!kmin) /* set kmin to 1 if k == 0 */
+				kmin++;
+			for (size_t k = (pbound-2).bitsize()-1; k > kmin; k--)
+			{
+				integer m = compute_max_m (pbound, k);
+				/* test only odd value of m, so k is exactly the 2-valuation */
+				if (!Givaro::isOdd (m))
+					m--;
+				for ( ; m > 0; m -= 2)
+				{
+					p = (m << k) + 1; /* p = m*2^k+1 */
+					if (probab_prime (p, probab_prime_ntests))
+					{
+						primes.push_back (p);
+						prod *= p;
+						if (prod > prodbound)
+							return true;
 					}
 				}
 			}
-
-
-#endif
-			return false; // false -> Could not find enough primes
+			return false;
 		}
 
-		/** @brief setSeed (unsigned long ul)
-		 *  Set the random seed to be ul.
-		 */
-		void static setSeed(unsigned long ul)
+		/* Set the random seed */
+		static inline void seeding (uint64_t seed)
 		{
-			integer::seeding(ul);
+			integer::seeding (seed);
+		}
+		static inline void seeding (const Integer &seed)
+		{
+			integer::seeding (seed);
+		}
+		static inline void seeding ()
+		{
+			integer::seeding ();
+		}
+
+	private:
+		RandomFFTPrime ()
+		{
+		}
+
+		/* Given bound and k, compute maximum value of m such that
+		 *      m*2^k+1 < bound  (Eq. 1)
+		 *
+		 * (Eq. 1) <=>   m < (bound-1)/2^k
+		 *              <=>   m <= ((bound-1) >> k)-1      if 2^k | bound-1
+		 *                    m <= (bound-1) >> k          otherwise
+		 */
+		static inline PrimeType compute_max_m (const PrimeType &bound, size_t k)
+		{
+			integer B = bound-1;
+			B = (B & (uint64_t) ((1<<k) - 1)) ? (B >> k) : (B >> k) - 1;
+			return B;
 		}
 	};
 }

--- a/tests/test-matpoly-mult.C
+++ b/tests/test-matpoly-mult.C
@@ -200,8 +200,10 @@ bool runTest(uint64_t n, uint64_t d, long seed){
 	size_t bits= (53-integer(n).bitsize())/2;
 	// fourier prime < 2^(53--log(n))/2
 	{
-		RandomFFTPrime Rd(1<<bits,seed);
-		integer p = Rd.randomPrime(integer(d).bitsize()+1);
+		integer p;
+		RandomFFTPrime::seeding (seed);
+		if (!RandomFFTPrime::randomPrime (p, 1<<bits, integer(d).bitsize()+1))
+			throw LinboxError ("RandomFFTPrime::randomPrime failed");
 		
 		Givaro::Modular<double> F((int32_t)p);
 		ok&=launchTest (F,n,bits,d,seed);

--- a/tests/test-order-basis.C
+++ b/tests/test-order-basis.C
@@ -124,8 +124,10 @@ bool runTest(uint64_t m,uint64_t n, uint64_t d, long seed){
     
 	// fourier prime < 2^(53--log(n))/2
 	{
-		RandomFFTPrime Rd(1<<bits,seed);
-		integer p = Rd.randomPrime(integer(d).bitsize()+1);		
+		integer p;
+		RandomFFTPrime::seeding (seed);
+		if (!RandomFFTPrime::randomPrime (p, 1<<bits, integer(d).bitsize()+1))
+			throw LinboxError ("RandomFFTPrime::randomPrime failed");
 		SmallField  F((int32_t)p);
         typename SmallField::RandIter G(F,0,seed);
         report<<"   - checking with small FFT prime p="<<p<<endl;


### PR DESCRIPTION
This PR fixes issue #175 
I change a little the interface to RandomFFTPrime and updated the code in linbox where it was necessary.
In doing so, I found a call to RandomFFTPrime that seems weird. In `linbox/algorithms/matpoly-mult.h`, there is four calls to generates random FFT primes less than `bit` and not `2^bit` as I would have expected. `bit` is indeed a number of bits, so a small number. Do we really want prime less than `bit` or is it a typo ?