### PR TITLE
Add tests for toeplitz apply/applyTranspose with non-square dimensions

### DIFF
--- a/linbox/blackbox/toeplitz.inl
+++ b/linbox/blackbox/toeplitz.inl
@@ -395,9 +395,10 @@ namespace LinBox
 		std::cout <<"pxOut is " << pxOut << std::endl;
 #endif
 
+		size_t M = this->rowdim();
 		size_t N = this->coldim();
 		for( size_t i = 0; i < N; ++i )
-			this->P.getCoeff(v_out[i], pOut, N-1+i);
+			this->P.getCoeff(v_out[i], pOut, M-1+i);
 
 		return v_out;
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -187,7 +187,8 @@ FULLCHECK_TESTS =               \
 	test-vector-domain			\
 	test-zero-one				\
 	test-weak-popov-form        \
-    test-mpi-comm
+    test-mpi-comm				\
+    test-toeplitz
 
 # Really just one or two of these would be enough for target check.
 # The rest can be in target fullcheck.
@@ -375,6 +376,7 @@ test_frobenius_small_SOURCES =          test-frobenius-small.C
 test_frobenius_large_SOURCES =          test-frobenius-large.C
 test_weak_popov_form_SOURCES =          test-weak-popov-form.C
 test_mpi_comm_SOURCES =                 test-mpi-comm.C
+test_toeplitz_SOURCES =                 test-toeplitz.C
 
 # Perfpublisher script interaction - AB 2014/12/11
 perfpublisher:

--- a/tests/test-toeplitz.C
+++ b/tests/test-toeplitz.C
@@ -1,0 +1,154 @@
+#include "linbox/linbox-config.h"
+#include "linbox/util/commentator.h"
+#include "test-common.h"
+
+#include <iostream>
+#include <fstream>
+#include <cstdio>
+
+#include "linbox/matrix/matrix-domain.h"
+#include "linbox/blackbox/toeplitz.h"
+
+using namespace LinBox;
+
+typedef NTL_zz_pX PolynomialRing;
+typedef typename PolynomialRing::Element Polynomial;
+typedef typename PolynomialRing::Coeff Coeff;
+
+typedef typename PolynomialRing::CoeffField Field;
+typedef typename Field::Element Element;
+typedef typename Field::RandIter RandIter;
+
+typedef BlasMatrixDomain<Field> MatrixDom;
+typedef typename MatrixDom::OwnMatrix Matrix;
+
+class Helper {
+    Field _F;
+    PolynomialRing _R;
+    RandIter _RI;
+    
+public:
+    Helper(const Field &F, const PolynomialRing &R) : _F(F), _R(R), _RI(F) {}
+    
+    void printMatrix(Matrix &M) const {
+        for (size_t i = 0; i < M.rowdim(); i++) {
+            for (size_t j = 0; j < M.coldim(); j++) {
+                Element e;
+                M.getEntry(e, i, j);
+                _F.write(std::cout, e) << " ";
+            }
+            std::cout << std::endl;
+        }
+        std::cout << std::endl;
+    }
+    
+    void randomPolynomial(Polynomial &f, size_t degree) const {
+        _R.assign(f, _R.zero);
+		
+		for (size_t i = 0; i <= degree; i++) {
+			Coeff c;
+			_RI.random(c);
+			_R.setCoeff(f, i, c);
+		}
+    }
+    
+    void randomVector(BlasVector<Field> &V) const {
+        for (size_t i = 0; i < V.size(); i++) {
+            Element e;
+            _RI.random(e);
+            V.setEntry(i, e);
+        }
+    }
+    
+    void initToeplitzMatrix(Matrix &M, const Polynomial &f) const {        
+        for (size_t i = 0; i <  M.rowdim(); i++) {
+            for (size_t j = 0; j < M.coldim(); j++) {
+                Coeff c;
+                _R.getCoeff(c, f, M.coldim() + i - j - 1);
+                M.setEntry(i, j, c);
+            }
+        }
+    }
+    
+    bool testApply(size_t rowdim, size_t coldim) const {
+        Polynomial f;
+        randomPolynomial(f, rowdim + coldim - 2);
+        
+        Toeplitz<Field, PolynomialRing> T(_R, f, rowdim, coldim);
+        Matrix M(_F, rowdim, coldim);
+        initToeplitzMatrix(M, f);
+        
+        BlasVector<Field> vIn(_F, coldim);
+        BlasVector<Field> vOut1(_F, rowdim), vOut2(_F, rowdim);
+        randomVector(vIn);
+        
+        M.apply(vOut1, vIn);
+        T.apply(vOut2, vIn);
+        
+        VectorDomain<Field> VD(_F);
+        if (!VD.areEqual(vOut1, vOut2)) {
+            return false;
+        }
+        
+        return true;
+    }
+    
+    bool testApplyTranspose(size_t rowdim, size_t coldim) const {
+        Polynomial f;
+        randomPolynomial(f, rowdim + coldim - 2);
+        
+        Toeplitz<Field, PolynomialRing> T(_R, f, rowdim, coldim);
+        Matrix M(_F, rowdim, coldim);
+        initToeplitzMatrix(M, f);
+        
+        BlasVector<Field> vIn(_F, rowdim);
+        BlasVector<Field> vOut1(_F, coldim), vOut2(_F, coldim);
+        randomVector(vIn);
+        
+        M.applyTranspose(vOut1, vIn);
+        T.applyTranspose(vOut2, vIn);
+        
+        VectorDomain<Field> VD(_F);
+        if (!VD.areEqual(vOut1, vOut2)) {
+            return false;
+        }
+        
+        return true;
+    }
+};
+
+int main(int argc, char **argv) {
+    
+    size_t rowdim = 3, coldim = 4;
+    size_t p = 10007;
+    
+    static Argument args[] = {
+        { 'n', "-n N", "Set row dimension of test matrices.", TYPE_INT, &rowdim },
+        { 'm', "-m M", "Set column dimension of test matrices.", TYPE_INT, &coldim },
+        { 'p', "-p P", "Set field cardinality.", TYPE_INT, &p },
+        END_OF_ARGUMENTS
+    };
+    parseArguments (argc, argv, args);
+    
+    commentator().start("Toeplitz test suite", "toeplitz");
+    bool pass = true;
+    
+    Field F(p);
+    PolynomialRing R(F);
+    
+    Helper H(F, R);
+    
+    pass = pass && H.testApply(rowdim, coldim);
+    pass = pass && H.testApplyTranspose(rowdim, coldim);
+    
+	commentator().stop(MSG_STATUS (pass),"Toeplitz test suite");
+    return pass ? 0 : -1;
+}
+
+// Local Variables:
+// mode: C++
+// tab-width: 4
+// indent-tabs-mode: nil
+// c-basic-offset: 4
+// End:
+// vim:sts=4:sw=4:ts=4:et:sr:cino=>s,f0,{0,g0,(0,\:0,t0,+0,=s


### PR DESCRIPTION
I wrote an implementation of the Frobenius form algorithm presented [here](https://link.springer.com/chapter/10.1007%2F978-3-642-57201-2_30) (see algorithms/frobenius-large.h) and uncovered a bug in the Toeplitz black box implementation that causes apply/applyTranpose to compute incorrect results for asymmetric matrices.

I had previously fixed apply, but this is a pull request with tests for apply/applyTranspose and a fix for applyTranspose.