### PR TITLE
Seed is uint64 t

### DIFF
--- a/linbox/algorithms/lifting-container.h
+++ b/linbox/algorithms/lifting-container.h
@@ -153,8 +153,8 @@ namespace LinBox
             this->_intRing.convert(Prime,_p);
 
             auto hb = RationalSolveHadamardBound(A, b);
-            N = Integer(1) << static_cast<size_t>(std::ceil(hb.numLogBound));
-            D = Integer(1) << static_cast<size_t>(std::ceil(hb.denLogBound));
+            N = Integer(1) << static_cast<uint64_t>(std::ceil(hb.numLogBound));
+            D = Integer(1) << static_cast<uint64_t>(std::ceil(hb.denLogBound));
 
             // L = N * D * 2
             // _length = logp(L, Prime) = log2(L) * ln(2) / ln(Prime)

--- a/linbox/randiter/abstract.h
+++ b/linbox/randiter/abstract.h
@@ -71,7 +71,7 @@ namespace LinBox
 		 */
 		virtual RandIterAbstract *construct (const FieldAbstract &F,
 						     const integer &size = 0,
-						     const integer &seed = 0) const = 0;
+						     const uint64_t &seed = 0) const = 0;
 
 		/** Virtual copy constructor.
 		 * Required because constructors cannot be virtual.

--- a/linbox/randiter/abstract.h
+++ b/linbox/randiter/abstract.h
@@ -71,7 +71,7 @@ namespace LinBox
 		 */
 		virtual RandIterAbstract *construct (const FieldAbstract &F,
 						     const integer &size = 0,
-						     const uint64_t &seed = 0) const = 0;
+						     const uint64_t seed = 0) const = 0;
 
 		/** Virtual copy constructor.
 		 * Required because constructors cannot be virtual.

--- a/linbox/randiter/archetype.h
+++ b/linbox/randiter/archetype.h
@@ -89,7 +89,7 @@ namespace LinBox
 		 */
 		RandIterArchetype (const FieldArchetype &F,
 				   const integer &size = 0,
-				   const uint64_t &seed = 0)
+				   const uint64_t seed = 0)
                         {_randIter_ptr = F._randIter_ptr->construct (*(F._field_ptr), size, seed);}
 
 		/** Copy constructor.
@@ -116,7 +116,7 @@ namespace LinBox
 		template<class Field_qcq>
 		RandIterArchetype (Field_qcq *f,
 				   const integer &size = 0,
-				   const uint64_t &seed = 0)
+				   const uint64_t seed = 0)
 		{ constructor (f, f, size, seed); }
 
 
@@ -200,7 +200,7 @@ namespace LinBox
 		void constructor (FieldAbstract *trait,
 				  Field_qcq     *field_ptr,
 				  const integer &size = 0,
-				  const uint64_t &seed = 0)
+				  const uint64_t seed = 0)
 		{
 			typename Field_qcq::RandIter FRI(*field_ptr);
 			_randIter_ptr = FRI->construct (*field_ptr, size, seed);
@@ -218,7 +218,7 @@ namespace LinBox
 		void constructor (void      *trait,
 				  Field_qcq *field_ptr,
 				  const integer &size = 0,
-				  const integer &seed = 0)
+				  const integer seed = 0)
 		{
 			FieldEnvelope< Field_qcq > EnvF (*field_ptr);
 			constructor (static_cast<FieldAbstract*> (&EnvF), &EnvF, size, seed) ;

--- a/linbox/randiter/archetype.h
+++ b/linbox/randiter/archetype.h
@@ -89,7 +89,7 @@ namespace LinBox
 		 */
 		RandIterArchetype (const FieldArchetype &F,
 				   const integer &size = 0,
-				   const integer &seed = 0)
+				   const uint64_t &seed = 0)
                         {_randIter_ptr = F._randIter_ptr->construct (*(F._field_ptr), size, seed);}
 
 		/** Copy constructor.
@@ -116,7 +116,7 @@ namespace LinBox
 		template<class Field_qcq>
 		RandIterArchetype (Field_qcq *f,
 				   const integer &size = 0,
-				   const integer &seed = 0)
+				   const uint64_t &seed = 0)
 		{ constructor (f, f, size, seed); }
 
 
@@ -200,7 +200,7 @@ namespace LinBox
 		void constructor (FieldAbstract *trait,
 				  Field_qcq     *field_ptr,
 				  const integer &size = 0,
-				  const integer &seed = 0)
+				  const uint64_t &seed = 0)
 		{
 			typename Field_qcq::RandIter FRI(*field_ptr);
 			_randIter_ptr = FRI->construct (*field_ptr, size, seed);

--- a/linbox/randiter/envelope.h
+++ b/linbox/randiter/envelope.h
@@ -69,7 +69,7 @@ namespace LinBox
 		 */
 		RandIterEnvelope (const FieldEnvelope<Field> &F,
 				  const integer &size = 0,
-				  const integer &seed = 0) :
+				  const uint64_t &seed = 0) :
 			_randIter (F._field, seed)
 		{}
 
@@ -127,7 +127,7 @@ namespace LinBox
 		 */
 		RandIterAbstract *construct (const FieldAbstract &F,
 					     const integer &size = 0,
-					     const integer &seed = 0) const
+					     const uint64_t &seed = 0) const
 		{
 			return new RandIterEnvelope (static_cast<const FieldEnvelope<Field>&> (F), size, seed);
 		}

--- a/linbox/randiter/envelope.h
+++ b/linbox/randiter/envelope.h
@@ -69,7 +69,7 @@ namespace LinBox
 		 */
 		RandIterEnvelope (const FieldEnvelope<Field> &F,
 				  const integer &size = 0,
-				  const uint64_t &seed = 0) :
+				  const uint64_t seed = 0) :
 			_randIter (F._field, seed)
 		{}
 
@@ -127,7 +127,7 @@ namespace LinBox
 		 */
 		RandIterAbstract *construct (const FieldAbstract &F,
 					     const integer &size = 0,
-					     const uint64_t &seed = 0) const
+					     const uint64_t seed = 0) const
 		{
 			return new RandIterEnvelope (static_cast<const FieldEnvelope<Field>&> (F), size, seed);
 		}

--- a/linbox/randiter/generic.h
+++ b/linbox/randiter/generic.h
@@ -92,7 +92,7 @@ namespace LinBox
 		 */
 		GenericRandIter (const Field &F,
 				 const integer &size = 0,
-				 const integer &seed = 0) :
+				 const uint64_t seed = 0) :
 			_field (F), _size (size), _seed (seed)
 		{
 			if (_seed == 0) _seed = time (NULL);
@@ -162,7 +162,7 @@ namespace LinBox
 		integer _size;
 
 		/// Seed
-		long _seed;
+		uint64_t _seed;
 
 	}; // class GenericRandIter
 }

--- a/linbox/randiter/lidia-gfq.h
+++ b/linbox/randiter/lidia-gfq.h
@@ -52,10 +52,10 @@ namespace LinBox
 		 */
 		LidiaGfqRandIter(const field& F,
 				 const integer& size = 0,
-				 const integer& seed = 0) :
+				 const uint64_t seed = 0) :
 			_size(size), _seed(seed) , GF(F)
 		{
-			if (_seed == integer(0)) _seed = time(NULL);
+			if (_seed == 0) _seed = time(NULL);
 
 			integer cardinality ;
 			F.cardinality(cardinality);
@@ -133,7 +133,7 @@ namespace LinBox
 		integer _size;
 
 		/// Seed
-		integer _seed;
+		uint64_t _seed;
 
 		field GF;
 

--- a/linbox/randiter/modular-balanced.h
+++ b/linbox/randiter/modular-balanced.h
@@ -97,7 +97,7 @@ namespace LinBox
 		 */
 		Givaro::ModularBalancedRandIter (const Givaro::ModularBalanced<Element> &F,
 					 const integer &size = 0,
-					 const integer &seed = 0) :
+					 const unit64_t &seed = 0) :
 			_field (F), _size (size), _seed (seed)
 		{
 			if (_seed == 0) _seed = time (NULL);
@@ -180,7 +180,7 @@ namespace LinBox
 		integer _size;
 
 		/// Seed
-		long _seed;
+		uint64_t _seed;
 
 	}; // class Givaro::ModularBalancedRandIter
 #endif

--- a/linbox/randiter/modular-balanced.h
+++ b/linbox/randiter/modular-balanced.h
@@ -97,7 +97,7 @@ namespace LinBox
 		 */
 		Givaro::ModularBalancedRandIter (const Givaro::ModularBalanced<Element> &F,
 					 const integer &size = 0,
-					 const unit64_t &seed = 0) :
+					 const unit64_t seed = 0) :
 			_field (F), _size (size), _seed (seed)
 		{
 			if (_seed == 0) _seed = time (NULL);

--- a/linbox/randiter/multimod-randomprime.h
+++ b/linbox/randiter/multimod-randomprime.h
@@ -47,13 +47,13 @@ namespace LinBox
 	public:
 
 
-		MultiModRandomPrime(size_t n=1, uint64_t bits = 30, unsigned long seed = 0) :
+		MultiModRandomPrime(size_t n=1, uint64_t bits = 30, uint64_t seed = 0) :
 			_bits(bits), _size(n)
 		{
 			_shift = integer(1)<<_bits;
 
 			if (! seed)
-				setSeed( (unsigned long) BaseTimer::seed() );
+				setSeed( (uint64_t) BaseTimer::seed() );
 			else
 				setSeed( seed );
 		}

--- a/linbox/randiter/param-fuzzy.h
+++ b/linbox/randiter/param-fuzzy.h
@@ -49,20 +49,20 @@ namespace LinBox
 
 		ParamFuzzyRandIter (/*const ParamFuzzy &F, */
 				   const integer &size = 0,
-				   const integer &seed = 0) :
+				   const uint64_t &seed = 0) :
 		       	_field (ParamFuzzy()), _size (size), _seed (seed)
 		{
 			/*if (_size == 0) F.cardinality (_size);*/
-			if (_seed == 0) _seed = (int64_t)time (NULL);
+			if (_seed == 0) _seed = (uint64_t)time (NULL);
 		}
 
 		ParamFuzzyRandIter (const ParamFuzzy &F,
 				    const integer &size = 0,
-				    const integer &seed = 0) :
+				    const uint64_t seed = 0) :
 		       	_field (F), _size (size), _seed (seed)
 		{
 			if (_size == 0) F.cardinality (_size);
-			if (_seed == 0) _seed = (int64_t)time (NULL);
+			if (_seed == 0) _seed = (uint64_t)time (NULL);
 		}
 
 		ParamFuzzyRandIter (const ParamFuzzyRandIter &R) :
@@ -110,7 +110,7 @@ namespace LinBox
 		integer _size;
 
 		/// Seed
-		integer _seed;
+		uint64_t _seed;
 
 	}; // class ParamFuzzyRandIter : public ParamFuzzyRandIter
 

--- a/linbox/randiter/param-fuzzy.h
+++ b/linbox/randiter/param-fuzzy.h
@@ -49,11 +49,11 @@ namespace LinBox
 
 		ParamFuzzyRandIter (/*const ParamFuzzy &F, */
 				   const integer &size = 0,
-				   const uint64_t &seed = 0) :
+				   const uint64_t seed = 0) :
 		       	_field (ParamFuzzy()), _size (size), _seed (seed)
 		{
 			/*if (_size == 0) F.cardinality (_size);*/
-			if (_seed == 0) _seed = (uint64_t)time (NULL);
+			if (_seed == 0) _seed = time (NULL);
 		}
 
 		ParamFuzzyRandIter (const ParamFuzzy &F,
@@ -62,7 +62,7 @@ namespace LinBox
 		       	_field (F), _size (size), _seed (seed)
 		{
 			if (_size == 0) F.cardinality (_size);
-			if (_seed == 0) _seed = (uint64_t)time (NULL);
+			if (_seed == 0) _seed = time (NULL);
 		}
 
 		ParamFuzzyRandIter (const ParamFuzzyRandIter &R) :

--- a/linbox/ring/ntl/ntl-gf2e.h
+++ b/linbox/ring/ntl/ntl-gf2e.h
@@ -206,7 +206,7 @@ public :
 		typedef NTL::GF2E Element;
 		UnparametricRandIter<NTL::GF2E>(const NTL_GF2E & F,
                                         const size_t& size = 0,
-                                        const size_t& seed = 0
+                                        const uint64_t& seed = 0
                                         ) :
                 _size(size), _seed(seed)
             {
@@ -234,7 +234,7 @@ public :
 
 	protected:
 		size_t _size;
-		size_t _seed;
+		uint64_t _seed;
 	};
 
 

--- a/linbox/ring/ntl/ntl-gf2e.h
+++ b/linbox/ring/ntl/ntl-gf2e.h
@@ -206,7 +206,7 @@ public :
 		typedef NTL::GF2E Element;
 		UnparametricRandIter<NTL::GF2E>(const NTL_GF2E & F,
                                         const size_t& size = 0,
-                                        const uint64_t& seed = 0
+                                        const uint64_t seed = 0
                                         ) :
                 _size(size), _seed(seed)
             {

--- a/linbox/ring/ntl/ntl-lzz_p.h
+++ b/linbox/ring/ntl/ntl-lzz_p.h
@@ -340,10 +340,10 @@ namespace LinBox
 
 		UnparametricRandIter<NTL::zz_p> (const NTL_zz_p & F,
                                          const integer& size=0,
-                                         const integer& seed=0) :
+                                         const uint64_t& seed=0) :
                 _size(size), _seed(seed), _ring(F)
             {
-                if (_seed == integer(0)) _seed = int64_t(time(NULL));
+                if (_seed == 0) _seed = int64_t(time(NULL));
 
                 integer cardinality;
                 F.cardinality(cardinality);
@@ -375,7 +375,8 @@ namespace LinBox
             }
         const NTL_zz_p& ring() const { return _ring; }
 	protected :
-		integer _size,_seed ;
+		integer _size;
+        uint64_t _seed ;
         const NTL_zz_p& _ring;
 	};
 

--- a/linbox/ring/ntl/ntl-lzz_p.h
+++ b/linbox/ring/ntl/ntl-lzz_p.h
@@ -340,10 +340,10 @@ namespace LinBox
 
 		UnparametricRandIter<NTL::zz_p> (const NTL_zz_p & F,
                                          const integer& size=0,
-                                         const uint64_t& seed=0) :
+                                         const uint64_t seed=0) :
                 _size(size), _seed(seed), _ring(F)
             {
-                if (_seed == 0) _seed = int64_t(time(NULL));
+                if (_seed == 0) _seed = time(NULL);
 
                 integer cardinality;
                 F.cardinality(cardinality);

--- a/linbox/ring/ntl/ntl-lzz_pe.h
+++ b/linbox/ring/ntl/ntl-lzz_pe.h
@@ -395,7 +395,7 @@ namespace LinBox
 		typedef NTL::zz_pE Element;
 		UnparametricRandIter<NTL::zz_pE>(const NTL_zz_pE & F ,
                                          const size_t& size = 0,
-                                         const uint64_t& seed = 0
+                                         const uint64_t seed = 0
                                          ) :
                 _size(size), _seed(seed), _ring(F)
             {

--- a/linbox/ring/ntl/ntl-lzz_pe.h
+++ b/linbox/ring/ntl/ntl-lzz_pe.h
@@ -395,7 +395,7 @@ namespace LinBox
 		typedef NTL::zz_pE Element;
 		UnparametricRandIter<NTL::zz_pE>(const NTL_zz_pE & F ,
                                          const size_t& size = 0,
-                                         const size_t& seed = 0
+                                         const uint64_t& seed = 0
                                          ) :
                 _size(size), _seed(seed), _ring(F)
             {
@@ -424,7 +424,7 @@ namespace LinBox
 
 	protected:
 		size_t _size;
-		size_t _seed;
+		uint64_t _seed;
         const NTL_zz_pE& _ring;
 	}; // class UnparametricRandIters
 	

--- a/linbox/ring/ntl/ntl-lzz_pex.h
+++ b/linbox/ring/ntl/ntl-lzz_pex.h
@@ -528,7 +528,7 @@ namespace LinBox
 		typedef NTL::zz_pEX Element;
 		UnparametricRandIter<NTL::zz_pEX>(const NTL_zz_pEX & F ,
                                           const size_t& size = 0,
-                                          const size_t& seed = 0
+                                          const uint64_t& seed = 0
                                           ) :
                 _size(size), _seed(seed), _ring(F)
             {
@@ -558,7 +558,7 @@ namespace LinBox
 
 	protected:
 		size_t _size;
-		size_t _seed;
+		uint64_t _seed;
         const NTL_zz_pEX& _ring;
 	}; // class UnparametricRandIters
 

--- a/linbox/ring/ntl/ntl-lzz_pex.h
+++ b/linbox/ring/ntl/ntl-lzz_pex.h
@@ -528,7 +528,7 @@ namespace LinBox
 		typedef NTL::zz_pEX Element;
 		UnparametricRandIter<NTL::zz_pEX>(const NTL_zz_pEX & F ,
                                           const size_t& size = 0,
-                                          const uint64_t& seed = 0
+                                          const uint64_t seed = 0
                                           ) :
                 _size(size), _seed(seed), _ring(F)
             {

--- a/linbox/ring/ntl/ntl-lzz_px.h
+++ b/linbox/ring/ntl/ntl-lzz_px.h
@@ -582,7 +582,7 @@ namespace LinBox
 		typedef NTL::zz_pX Element;
 		UnparametricRandIter<NTL::zz_pX>(const NTL_zz_pX & F ,
 						 const size_t& size = 0,
-						 const size_t& seed = 0
+						 const uint64_t& seed = 0
 						) :
                 _size(size), _seed(seed), _ring(F)
 		{
@@ -621,7 +621,7 @@ namespace LinBox
 
 	protected:
 		size_t _size;
-		size_t _seed;
+		uint64_t _seed;
         const NTL_zz_pX& _ring;
 	}; // class UnparametricRandIters
 	

--- a/linbox/ring/ntl/ntl-rr.h
+++ b/linbox/ring/ntl/ntl-rr.h
@@ -280,16 +280,17 @@ namespace LinBox
 	class UnparametricRandIter<NTL::RR> {
 		typedef NTL::RR Element ;
 	protected:
-		integer _size,_seed;
+		integer _size;
+        uint64_t _seed;
         const NTL_RR& _ring;
 	public:
 
 		UnparametricRandIter<NTL::RR> (const NTL_RR & F,
 					       const integer& size = 0,
-					       const integer& seed = 0) :
+					       const uint64_t seed = 0) :
                 _size(size), _seed(seed), _ring(F)
 		{
-			if (_seed == integer(0)) _seed = int64_t(time(NULL));
+			if (_seed == 0) _seed = uint64_t(time(NULL));
 
 			// integer cardinality;
 			// F.cardinality(cardinality);

--- a/linbox/ring/ntl/ntl-rr.h
+++ b/linbox/ring/ntl/ntl-rr.h
@@ -290,7 +290,7 @@ namespace LinBox
 					       const uint64_t seed = 0) :
                 _size(size), _seed(seed), _ring(F)
 		{
-			if (_seed == 0) _seed = uint64_t(time(NULL));
+			if (_seed == 0) _seed = time(NULL);
 
 			// integer cardinality;
 			// F.cardinality(cardinality);

--- a/linbox/ring/ntl/ntl-zz_p.h
+++ b/linbox/ring/ntl/ntl-zz_p.h
@@ -475,16 +475,17 @@ namespace LinBox
 	template <>
 	class UnparametricRandIter<NTL::ZZ_p> {
 	protected:
-		integer _size,_seed;
+		integer _size;
+        uint64_t _seed;
         const NTL_ZZ_p & _ring;
 	public:
 
 		UnparametricRandIter<NTL::ZZ_p> (const NTL_ZZ_p & F,
 						 const integer& size = 0,
-						 const integer& seed = 0) :
+						 const uint64_t seed = 0) :
                 _size(size), _seed(seed), _ring(F)
 		{
-			if (_seed == integer(0)) _seed = int64_t(time(NULL));
+			if (_seed == 0) _seed = uint64_t(time(NULL));
 
 			integer cardinality;
 			F.cardinality(cardinality);

--- a/linbox/ring/ntl/ntl-zz_pe.h
+++ b/linbox/ring/ntl/ntl-zz_pe.h
@@ -380,7 +380,7 @@ namespace LinBox
 		typedef NTL::ZZ_pE Element;
 		UnparametricRandIter<NTL::ZZ_pE>(const NTL_ZZ_pE & F ,
 						 const int32_t& size =0,
-						 const int32_t& seed =0
+						 const uint64_t & seed =0
 						) :
                 _size(size), _seed(seed), _ring(F)
 		{
@@ -427,7 +427,7 @@ namespace LinBox
 
 	protected:
 		size_t _size;
-		size_t _seed;
+		uint64_t _seed;
         const NTL_ZZ_pE& _ring; 
 	};
 }

--- a/linbox/solutions/hadamard-bound.h
+++ b/linbox/solutions/hadamard-bound.h
@@ -302,7 +302,7 @@ namespace LinBox {
             return 0.0;
         }
 
-        auto n = std::max(A.rowdim(), A.coldim());
+        uint64_t n = std::max(A.rowdim(), A.coldim());
         double logBound = static_cast<double>(n) * (Givaro::logtwo(n) / 2.0 + Givaro::logtwo(max));
         return logBound;
     }

--- a/linbox/util/serialization.inl
+++ b/linbox/util/serialization.inl
@@ -210,7 +210,7 @@ namespace LinBox {
         __mpz_struct* mpzStruct = integer.get_mpz();
 
         int32_t mpSize;
-        uint32_t bytesRead = 0u;
+        uint64_t bytesRead = 0u;
         bytesRead += unserialize(mpSize, bytes, offset + bytesRead);
 
         mpzStruct->_mp_alloc = std::abs(mpSize);
@@ -218,7 +218,9 @@ namespace LinBox {
         _mpz_realloc(mpzStruct, mpzStruct->_mp_alloc);
 
         for (auto i = 0, l = std::abs(mpSize); i < l; ++i) {
-            bytesRead += unserialize(mpzStruct->_mp_d[i], bytes, offset + bytesRead);
+            uint64_t tmp;
+            bytesRead += unserialize(tmp, bytes, offset + bytesRead);
+            mpzStruct->_mp_d[i] = tmp;
         }
 
         return bytesRead;

--- a/linbox/vector/stream.h
+++ b/linbox/vector/stream.h
@@ -337,7 +337,7 @@ namespace LinBox
 		 * @param m Number of vectors to return (0 for unlimited)
 		 * @param seed
 		 */
-		RandomSparseStream (const Field &F, RandIter &r, double p, size_t n, size_t m = 0, int seed=(int)time (NULL));
+		RandomSparseStream (const Field &F, RandIter &r, double p, size_t n, size_t m = 0, uint64_t seed=(uint64_t)time (NULL));
 
 		/** Get next element
 		 * @param v Vector into which to generate random vector
@@ -381,9 +381,9 @@ namespace LinBox
 		typedef _Vector Vector;
 		typedef RandomSparseStream<Field, Vector, RandIter, VectorCategories::DenseVectorTag > Self_t;
 
-		RandomSparseStream (const Field &F, RandIter &r, double p, size_t n, size_t m = 0, int seed=(int)time (NULL)) :
+		RandomSparseStream (const Field &F, RandIter &r, double p, size_t n, size_t m = 0, uint64_t seed=(uint64_t)time (NULL)) :
 			_field (F), _r1 (r), _r (_r1), _n (n), _p (p), _m (m), _j (0),
-			MT ((uint32_t)seed)
+			MT (static_cast<uint32_t>(seed))
 		{
 			linbox_check ((p >= 0.0) && (p <= 1.0));
 		}
@@ -437,7 +437,7 @@ namespace LinBox
 		typedef _Vector Vector;
 
 		RandomSparseStream (const Field &F, RandIter &r, double p,
-				    size_t N, size_t M = 0, int seed=(int)time (NULL)) :
+				    size_t N, size_t M = 0, uint64_t seed=(int)time (NULL)) :
                 _field (F), 
                 _r1 (r), 
                 _r (r), 
@@ -445,7 +445,7 @@ namespace LinBox
                 _p (p), 
                 _m (M), 
                 _j (0),
-                MT ((uint32_t)seed)
+                MT (seed)
 		{ setP (p); }
 
 		Vector &get (Vector &v)
@@ -517,9 +517,9 @@ namespace LinBox
 		typedef RandomSparseStream<Field, Vector, RandIter, VectorCategories::SparseAssociativeVectorTag > Self_t;
 
 		RandomSparseStream (const Field &F, RandIter &r, double p, size_t N,
-				    size_t M = 0, int seed=(int)time (NULL)) :
+				    size_t M = 0, uint64_t seed=(uint64_t)time (NULL)) :
 			_field (F), _r1 (r), _r (_r1), _n (N), _k ((long) (p * N)), _j (0), _m (M),
-			MT ((uint32_t) seed)
+			MT (seed)
 		{}
 
 		Vector &get (Vector &v)
@@ -571,9 +571,9 @@ namespace LinBox
 		typedef _Vector Vector;
 		typedef RandomSparseStream<Field, Vector, RandIter, VectorCategories::SparseParallelVectorTag > Self_t;
 
-		RandomSparseStream (const Field &F, RandIter &r, double p, size_t nn, size_t mm = 0, int seed=(int)time (NULL)) :
+		RandomSparseStream (const Field &F, RandIter &r, double p, size_t nn, size_t mm = 0, uint64_t  seed=(int)time (NULL)) :
 			_field (F), _r1 (r), _r (_r1), _n (nn), _m (mm), _j (0),
-			MT ((uint32_t)seed)
+			MT (seed)
 		{ setP (p); }
 
 		Vector &get (Vector &v)

--- a/linbox/vector/stream.h
+++ b/linbox/vector/stream.h
@@ -437,7 +437,7 @@ namespace LinBox
 		typedef _Vector Vector;
 
 		RandomSparseStream (const Field &F, RandIter &r, double p,
-				    size_t N, size_t M = 0, uint64_t seed=(int)time (NULL)) :
+				    size_t N, size_t M = 0, uint64_t seed= time (NULL)) :
                 _field (F), 
                 _r1 (r), 
                 _r (r), 
@@ -445,7 +445,7 @@ namespace LinBox
                 _p (p), 
                 _m (M), 
                 _j (0),
-                MT (seed)
+                MT (static_cast<uint32_t>(seed))
 		{ setP (p); }
 
 		Vector &get (Vector &v)
@@ -517,9 +517,9 @@ namespace LinBox
 		typedef RandomSparseStream<Field, Vector, RandIter, VectorCategories::SparseAssociativeVectorTag > Self_t;
 
 		RandomSparseStream (const Field &F, RandIter &r, double p, size_t N,
-				    size_t M = 0, uint64_t seed=(uint64_t)time (NULL)) :
+				    size_t M = 0, uint64_t seed= time (NULL)) :
 			_field (F), _r1 (r), _r (_r1), _n (N), _k ((long) (p * N)), _j (0), _m (M),
-			MT (seed)
+			MT (static_cast<uint32_t>(seed))
 		{}
 
 		Vector &get (Vector &v)
@@ -571,9 +571,9 @@ namespace LinBox
 		typedef _Vector Vector;
 		typedef RandomSparseStream<Field, Vector, RandIter, VectorCategories::SparseParallelVectorTag > Self_t;
 
-		RandomSparseStream (const Field &F, RandIter &r, double p, size_t nn, size_t mm = 0, uint64_t  seed=(int)time (NULL)) :
+		RandomSparseStream (const Field &F, RandIter &r, double p, size_t nn, size_t mm = 0, uint64_t  seed= time (NULL)) :
 			_field (F), _r1 (r), _r (_r1), _n (nn), _m (mm), _j (0),
-			MT (seed)
+			MT (static_cast<uint32_t>(seed))
 		{ setP (p); }
 
 		Vector &get (Vector &v)

--- a/tests/test-randiter-nonzero-prime.C
+++ b/tests/test-randiter-nonzero-prime.C
@@ -129,8 +129,8 @@ bool testMask(PGenerator& genprime, unsigned int iterations, size_t numproc, siz
 	commentator().start ("Testing masked prime random elements", "testMaskedPrimeRandom", iterations);
 
     bool pass(true);
-    const size_t MAXMASK = ( (1U<<genprime.getShift())-1);
-    const size_t EXPECTS = (numproc<<1) | 0x1;
+    const uint64_t MAXMASK = ( (UINT64_C(1)<<genprime.getShift())-1);
+    const uint64_t EXPECTS = (numproc<<1) | 0x1;
     if (EXPECTS != genprime.getMask()) pass = false;
 
     for(size_t i=0; i<iterations; ++i, ++genprime) {

--- a/tests/test-serialization.C
+++ b/tests/test-serialization.C
@@ -174,7 +174,7 @@ bool test_field(const Integer& q)
 
     // --- Test dense vector
 
-    BlasVector<Field> denseVector(F, denseMatrix.rowdim(), denseMatrix.coldim());
+    BlasVector<Field> denseVector(F, denseMatrix.rowdim());
     for (auto i = 0u; i < denseMatrix.rowdim(); i++) {
         denseVector[i] = denseMatrix.getEntry(i, 0);
     }


### PR DESCRIPTION
The types used for seeds in LinBox vary a lot and cause numerous type conversion ambiguities with Givaro random iterators on OS-X where size_t is not silently converted into an uint64_t: https://ci.inria.fr/linbox/job/LinBox/290/
This PR fixes all such issues by changing all seeds to be uint64_t (excpect the one of Mersenne Twister which is already uint32_t since everything there is on 32 bits). 