### PR TITLE
Full CRA charpoly and minpoly

### DIFF
--- a/linbox/algorithms/cra-builder-full-multip.h
+++ b/linbox/algorithms/cra-builder-full-multip.h
@@ -1,7 +1,7 @@
 /* linbox/algorithms/cra-builder-full-multip.h
  * Copyright (C) 1999-2010 The LinBox group
  *
- * Time-stamp: <15 Dec 10 15:54:00 Jean-Guillaume.Dumas@imag.fr>
+ * Time-stamp: <09 May 19 16:50:52 Jean-Guillaume.Dumas@imag.fr>
  *
  * ========LICENCE========
  * This file is part of the library LinBox.
@@ -60,7 +60,7 @@ namespace LinBox
 	struct CRABuilderFullMultip {
 		typedef Domain_Type			Domain;
 		typedef typename Domain::Element DomainElement;
-		typedef CRABuilderFullMultip<Domain> 		Self_t;
+		typedef CRABuilderFullMultip<Domain>		Self_t;
 
     public:
         struct Shelf {
@@ -406,6 +406,14 @@ namespace LinBox
             u1 += temp; // u1 <-- u1 + ((u0-u1)/m1 mod m0) * m1
             return u1;
         }
+
+#ifdef _LB_CRATIMING
+    public:
+        std::ostream& reportTimes(std::ostream& os) const
+        {
+            return os <<  "FullMultip CRA total size:" << totalsize_;
+        }
+#endif
 
 	};
 

--- a/linbox/solutions/charpoly.h
+++ b/linbox/solutions/charpoly.h
@@ -212,48 +212,6 @@ namespace LinBox
 #include "linbox/algorithms/cia.h"
 namespace LinBox
 {
-#if 0
-
-	// The charpoly with Auto Method
-	template<class Blackbox, class Polynomial>
-	Polynomial& charpoly (Polynomial                        &P,
-			      const Blackbox                    &A,
-			      const RingCategories::IntegerTag  &tag,
-			      const Method::Auto              &M)
-	{
-                    // bb method broken, default to dense method
-                return charpoly(P, A, tag, Method::DenseElimination(M));
-//		return charpoly(P, A, tag, Method::Blackbox(M));
-	}
-#endif
-
-	template < class IntRing, class Polynomial>
-                   Polynomial& charpoly (Polynomial                       & P,
-			      const BlasMatrix<IntRing>         & A,
-			      const RingCategories::IntegerTag & tag,
-			      const Method::Auto             & M)
-	{
-		commentator().start ("BlasMatrix Integer Charpoly", "Icharpoly");
-		charpoly(P, A, tag, Method::DenseElimination(M) );
-		commentator().stop ("done", NULL, "Icharpoly");
-		return P;
-	}
-
-
-#if 0
-	template < class IntRing, class Polynomial >
-	Polynomial& charpoly (Polynomial                       & P,
-			      const BlasMatrix<IntRing>         & A,
-			      const RingCategories::IntegerTag & tag,
-			      const Method::Auto             & M)
-	{
-		commentator().start ("BlasMatrix Integer Charpoly", "Icharpoly");
-		charpoly(P, A, tag, Method::DenseElimination(M) );
-		commentator().stop ("done", NULL, "Icharpoly");
-		return P;
-	}
-#endif
-
 	/** @brief Compute the characteristic polynomial over {\bf Z}
 	 *
 	 * Compute the characteristic polynomial of a matrix using dense
@@ -296,7 +254,7 @@ namespace LinBox
 // 		typename Givaro::Poly1Dom<typename Blackbox::Field>::Element Pg;
 // 		return P = BBcharpoly::blackboxcharpoly (Pg, A, tag, M);
                     // BB method broken: default to dense method
-                return charpoly(P, A, tag, Method::DenseElimination(M) );
+        return charpoly(P, A, tag, Method::DenseElimination(M) );
                     //return BBcharpoly::blackboxcharpoly (P, A, tag, M);
 	}
 
@@ -313,117 +271,29 @@ namespace LinBox
 namespace LinBox
 {
 
-#if 0
-#include "linbox/algorithms/rational-cra-var-prec.h"
-#include "linbox/algorithms/cra-builder-var-prec-early-multip.h"
-#include "linbox/algorithms/charpoly-rational.h"
-
-	namespace LinBox
-{
-	template <class Blackbox, class MyMethod>
-	struct IntegerModularCharpoly {
-		const Blackbox &A;
-		const MyMethod &M;
-
-		IntegerModularCharpoly(const Blackbox& b, const MyMethod& n) :
-			A(b), M(n)
-		{}
-
-		template<typename Polynomial, typename Field>
-		IterationResult operator()(Polynomial& P, const Field& F) const {
-			typedef typename Blackbox::template rebind<Field>::other FBlackbox;
-			FBlackbox * Ap;
-			MatrixHom::map(Ap, A, F);
-			charpoly( P, *Ap, typename FieldTraits<Field>::categoryTag(), M);
-			integer p;
-			F.characteristic(p);
-                            //std::cerr<<"Charpoly(A) mod "<<p<<" = "<<P;
-
-			delete Ap;
-			return IterationResult::CONTINUE;
-		}
-	};
-#endif
-
-	template <class Blackbox, class Polynomial>
+	template <class Matrix, class Polynomial, class Method>
 	Polynomial& charpoly (Polynomial                       & P,
-			      const Blackbox                   & A,
-			      const RingCategories::IntegerTag & tag,
-			      const Method::Blackbox           & M)
+                          const Matrix                     & A,
+                          const RingCategories::IntegerTag & tag,
+                          const Method                     & M)
 	{
 		if (A.coldim() != A.rowdim())
 			throw LinboxError("LinBox ERROR: matrix must be square for characteristic polynomial computation\n");
 
-		commentator().start ("Integer BlackBox Charpoly : No NTL installation -> chinese remaindering", "IbbCharpoly");
+		commentator().start ("Integer Charpoly : chinese remaindering", "IntCharpoly");
 
         typedef Givaro::ModularBalanced<double> Field;
 		PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(A.coldim()));
-#if 0
-		typename Blackbox::ConstIterator it = A.Begin();
-		typename Blackbox::ConstIterator it_end = A.End();
-		integer max = 1,min=0;
-		while( it != it_end ){
-			//      cerr<<"it="<<(*it)<<endl;
-			if (max < (*it))
-				max = *it;
-			if ( min > (*it))
-				min = *it;
-			it++;
-		}
-		if (max<-min)
-			max=-min;
-		size_t n=A.coldim();
-		double hadamarcp = n/2.0*(log(double(n))+2*log(double(max))+0.21163275)/log(2.0);
 
-		ChineseRemainder< CRABuilderFullMultip<Field > > cra(hadamarcp);
-#endif
+            // @todo: use a value for the switch provided by the method and not by a macro
+#ifdef __LINBOX_HEURISTIC_CRA
 		ChineseRemainder< CRABuilderEarlyMultip<Field > > cra(LINBOX_DEFAULT_EARLY_TERMINATION_THRESHOLD);
-
-		IntegerModularCharpoly<Blackbox,Method::Blackbox> iteration(A, M);
+#else
+        double hbound = FastCharPolyHadamardBound(A);
+		ChineseRemainder< CRABuilderFullMultip<Field > > cra(hbound);
+#endif
+		IntegerModularCharpoly<Matrix, Method> iteration(A, M);
 		cra.operator() (P, iteration, genprime);
-		commentator().stop ("done", NULL, "IbbCharpoly");
-#ifdef _LB_CRATIMING
-        cra.reportTimes(std::clog);
-#endif
-		return P;
-	}
-
-
-	template <class Blackbox, class Polynomial>
-	Polynomial& charpoly (Polynomial                       & P,
-			      const Blackbox                   & A,
-			      const RingCategories::IntegerTag & tag,
-			      const Method::DenseElimination    & M)
-	{
-		if (A.coldim() != A.rowdim())
-			throw LinboxError("LinBox ERROR: matrix must be square for characteristic polynomial computation\n");
-
-		commentator().start ("Integer Dense Charpoly : No NTL installation -> chinese remaindering", "IbbCharpoly");
-
-        typedef Givaro::ModularBalanced<double> Field;
-		PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(A.coldim()));
-#if 0
-		typename Blackbox::ConstIterator it = A.Begin();
-		typename Blackbox::ConstIterator it_end = A.End();
-		integer max = 1,min=0;
-		while( it != it_end ){
-			if (max < (*it))
-				max = *it;
-			if ( min > (*it))
-				min = *it;
-			it++;
-		}
-		if (max<-min)
-			max=-min;
-		size_t n=A.coldim();
-		double hadamarcp = n/2.0*(log(double(n))+2*log(double(max))+0.21163275)/log(2.0);
-
-
-		ChineseRemainder< CRABuilderFullMultip<Field > > cra(hadamarcp);
-#endif
-		ChineseRemainder< CRABuilderEarlyMultip<Field > > cra(LINBOX_DEFAULT_EARLY_TERMINATION_THRESHOLD);
-        IntegerModularCharpoly<Blackbox,Method::DenseElimination> iteration(A, M);
-		cra (P, iteration, genprime);
 		commentator().stop ("done", NULL, "IbbCharpoly");
 #ifdef _LB_CRATIMING
         cra.reportTimes(std::clog);

--- a/linbox/solutions/charpoly.h
+++ b/linbox/solutions/charpoly.h
@@ -296,7 +296,7 @@ namespace LinBox
 		cra.operator() (P, iteration, genprime);
 		commentator().stop ("done", NULL, "IbbCharpoly");
 #ifdef _LB_CRATIMING
-        cra.reportTimes(std::clog);
+        cra.reportTimes(std::clog) << std::endl;
 #endif
 		return P;
 	}

--- a/linbox/solutions/hadamard-bound.h
+++ b/linbox/solutions/hadamard-bound.h
@@ -287,7 +287,7 @@ namespace LinBox {
      * This is a larger estimation but faster to compute.
      */
     template <class IMatrix>
-    double FastHadamardBound(const IMatrix& A)
+    inline double FastHadamardBound(const IMatrix& A, const MatrixCategories::RowColMatrixTag& tag)
     {
         Integer max = 0;
         for (auto it = A.Begin(); it != A.End(); ++it) {
@@ -307,6 +307,31 @@ namespace LinBox {
         return logBound;
     }
 
+    template <class IMatrix>
+    inline double FastHadamardBound(const IMatrix& A, const MatrixCategories::BlackboxTag& tag)
+    {
+        DenseMatrix<typename IMatrix::Field> ACopy(A);
+        return FastHadamardBound(ACopy);
+    }
+
+    template <class IMatrix>
+    inline double FastHadamardBound(const IMatrix& A)
+    {
+        typename MatrixTraits<IMatrix>::MatrixCategory tag;
+        return FastHadamardBound(A, tag);
+    }
+
+        /**
+         * Bound on the coefficients of the characteristic polynomial
+         * @bib "Efficient Computation of the Characteristic Polynomial". Dumas Pernet Wan ISSAC'05.
+         *
+         */
+    template <class IMatrix>
+    inline double FastCharPolyHadamardBound(const IMatrix& A)
+    {
+        return FastHadamardBound(A)+A.coldim()*.105815875; // .105815875 = 0.21163275 / 2
+    }
+    
     // ----- Rational solve bound
 
     struct RationalSolveHadamardBoundData {


### PR DESCRIPTION
Currently the charpoly and minpoly over ZZ use early terminated Chinese Remainder, with a fixed number of stabilization checks. This is a heuristic algorithm and has caused user test-cases to fail ( see
https://trac.sagemath.org/ticket/21579 and https://trac.sagemath.org/ticket/15535)
In the previous release, we made the decision to leave the heuristic variant as a default, claiming we would adress the problem. 
We therefore patched LinBox in sage, and other packagers had to also patch the library. See https://trac.sagemath.org/ticket/24214#comment:17
and following comments
We still did not address the problem, and I suggest the following changes implemented in this PR: 
- switch between Heuristic (EarlyTermination CRA) or Deterministic (FullCRA) in the charpoly and minpoly with IntegerTag.
- ideally the switch should be controlled by a parameter of the method. Unfortunately, we did not rework the structure of the methods so far, so let's keep it for a next step.
- for the moment, the switch is done by a macro `__LINBOX_HEURISTIC_CRA` which the user may define if she wants to use early terminated CRA.
- in the deterministic case, the charpoly-hadamard bound had bugs and was harcoded within the algorihtm. I wrote it in the recent `solutions/hadamard-bound.h` based on the existing `FastHadamardBound` function. This fixes #191 .