### PR TITLE
fabi-version=6 only if gcc version < 5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -175,11 +175,11 @@ LT_INIT([win32-dll])
 AC_CANONICAL_HOST
 case "${host_os}" in
     cygwin*|mingw*)
-        LINBOX_LDFLAGS=-no-undefined
-        ;;
+	LINBOX_LDFLAGS=-no-undefined
+	;;
     *)
-        LINBOX_LDFLAGS=""
-        ;;
+	LINBOX_LDFLAGS=""
+	;;
 esac
 AC_SUBST([LINBOX_LDFLAGS])
 
@@ -194,6 +194,12 @@ AC_SUBST(SIMD_FLAGS)
 
 dnl gcc-4.9.2 bug See https://trac.sagemath.org/ticket/17635#comment:178
 AS_IF([ test  "x$CCNAM" = "xgcc492" ],[CXXFLAGS="${CXXFLAGS} -fpermissive"],[])
+
+# With GCC 4.x, the default ABI version is 2. With this version, __m128 and
+# __m256 are the same types and therefore we cannot have overloads for both
+# types without linking error. It is fixed in ABI version 4.
+# FIXME: Why do we set ABI version to 6 ?
+AS_IF([test "x$CCNAM" = "xgccl5"],[REQUIRED_FLAGS+=" -fabi-version=6"])
 
 
 echo "-----------------------------------------------"

--- a/configure.ac
+++ b/configure.ac
@@ -199,7 +199,7 @@ AS_IF([ test  "x$CCNAM" = "xgcc492" ],[CXXFLAGS="${CXXFLAGS} -fpermissive"],[])
 # __m256 are the same types and therefore we cannot have overloads for both
 # types without linking error. It is fixed in ABI version 4.
 # FIXME: Why do we set ABI version to 6 ?
-AS_IF([test "x$CCNAM" = "xgccl5"],[REQUIRED_FLAGS+=" -fabi-version=6"])
+AS_CASE([$CCNAM], [gcc4*], [REQUIRED_FLAGS+=" -fabi-version=6"])
 
 
 echo "-----------------------------------------------"

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -167,6 +167,17 @@ dnl GCC > 4.2 ?
 		])
 		])
 
+    dnl GCC <= 5 ?
+    AS_IF([ test -z "${CCNAM}"], [
+        AC_TRY_RUN( [
+            #ifdef __GNUC__
+                int main() { return !(__GNUC__ < 5))) ; }
+            #else
+               not gcc neither.
+            #endif],
+            [ CCNAM=gccl5 ])
+        ])
+
 		dnl  autre ?
 
 		AS_IF([ test -z "${CCNAM}"],

--- a/macros/debug.m4
+++ b/macros/debug.m4
@@ -121,61 +121,37 @@ dnl 3.1 < CLANG <=  3.8 ?
 		])
 
 
-dnl GCC >= 4.8 ?
-		AS_IF([ test -z "${CCNAM}"], [
-			AC_TRY_RUN( [
-				#ifdef __GNUC__
-				   int main() { return !(__GNUC__ >= 5 || (__GNUC__ == 4  && __GNUC_MINOR__ > 7 )) ; }
-				#else
-				   pas gcc non plus ???
-				#endif], [
-		CCNOM=gcc
-		AS_IF([ test -n "${CC}" ], [CCNOM="`$CC --version 2>&1|  awk 'NR<2{print $1}'`"])
-		CCNAM=gcc48
-		AC_SUBST(CCNAM)
-		AC_MSG_RESULT($CCNOM)
-		])
-		])
-dnl GCC > 4.4 ?
-		AS_IF([ test -z "${CCNAM}"], [
-			AC_TRY_RUN( [
-				#ifdef __GNUC__
-				   int main() { return !( __GNUC__ == 4 && __GNUC_MINOR__ == 4 ) ; }
-				#else
-				   pas gcc non plus ???
-				#endif], [
-		CCNOM=gcc
-		AS_IF([ test -n "${CC}" ], [CCNOM="`$CC --version 2>&1|  awk 'NR<2{print $1}'`"])
-		CCNAM=gcc44
-		AC_SUBST(CCNAM)
-		AC_MSG_RESULT($CCNOM)
-		])
-		])
-dnl GCC > 4.2 ?
-		AS_IF([ test -z "${CCNAM}"], [
-			AC_TRY_RUN( [
-				#ifdef __GNUC__
-				   int main() { return !(__GNUC__ == 4 && __GNUC_MINOR__ > 2) ; }
-				#else
-				   pas gcc non plus ???
-				#endif], [
-		CCNOM=gcc
-		AS_IF([ test -n "${CC}" ], [CCNOM="`$CC --version 2>&1|  awk 'NR<2{print $1}'`"])
-		CCNAM=gcc
-		AC_SUBST(CCNAM)
-		AC_MSG_RESULT($CCNOM)
-		])
-		])
-
-    dnl GCC <= 5 ?
+    dnl GCC >= 5 ?
     AS_IF([ test -z "${CCNAM}"], [
         AC_TRY_RUN( [
             #ifdef __GNUC__
-                int main() { return !(__GNUC__ < 5))) ; }
+                int main() { return !(__GNUC__ >= 5 ) ; }
+            #else
+                not gcc neither.
+            #endif],
+            [ CCNAM=gcc ])
+        ])
+
+    dnl 4.3 <= GCC < 5 ?
+    AS_IF([ test -z "${CCNAM}"], [
+        AC_TRY_RUN( [
+            #ifdef __GNUC__
+                int main() { return !(__GNUC__ == 4 && __GNUC_MINOR__ >= 3) ; }
             #else
                not gcc neither.
             #endif],
-            [ CCNAM=gccl5 ])
+            [ CCNAM=gcc4 ])
+        ])
+
+    dnl GCC == 4.9.2 ?
+    AS_IF([ test -z "${CCNAM}"], [
+        AC_TRY_RUN( [
+            #ifdef __GNUC__
+                int main() { return !(__GNUC__ == 4  && __GNUC_MINOR__ == 9 && __GNUC_PATCHLEVEL__ == 2 ) ; }
+            #else
+               not gcc neither.
+            #endif],
+            [ CCNAM=gcc492 ])
         ])
 
 		dnl  autre ?


### PR DESCRIPTION
Uniformize fabi-version=6 only if gcc version < 5 in givaro/fflas/linbox.
Required as a kludge before cleanup the full autotools mechanisms, as otherwise there are incompatibilities between givaro/fflas/linbox.
See similar PR in givaro/linbox: [givaro-PR151](https://github.com/linbox-team/givaro/pull/151) and [fflas PR305](https://github.com/linbox-team/fflas-ffpack/pull/305).