### PR TITLE
[WIP] Add a folder "programs" for executables solving a single problem

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@
 
 ACLOCAL_AMFLAGS = -I macros
 
-SUBDIRS=linbox benchmarks tests interfaces doc examples
+SUBDIRS=linbox benchmarks tests interfaces doc examples programs
 
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = linbox.pc
@@ -55,6 +55,9 @@ examples:
 
 benchmarks:
 	(cd benchmarks; ${MAKE} benchmarks)
+
+programs:
+	(cd programs; ${MAKE} programs)
 
 perfpublisher: benchmarks/perfpublisher tests/perfpublisher
 

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,8 @@ interfaces/kaapi/Makefile
 benchmarks/Makefile
 benchmarks/data/Makefile
 benchmarks/matrix/Makefile
+programs/Makefile
+programs/smith/Makefile
 linbox.pc
 ])
 

--- a/programs/Makefile.am
+++ b/programs/Makefile.am
@@ -1,0 +1,4 @@
+SUBDIRS=smith
+
+programs:
+	(cd smith; ${MAKE} programs)

--- a/programs/smith/Makefile.am
+++ b/programs/smith/Makefile.am
@@ -1,0 +1,1 @@
+programs:


### PR DESCRIPTION
Currently the "examples" folder plays two roles:
1. demonstrate simple examples of usage of the code
2. provide binaries for solving a single problem, such as Det, Rank etc

This PR aims at separating these 2 functions, by introducing a "programs" folder in which the executables solving single problems will be located, leaving the "examples" folder to the role of simple code examples for tutorials.