### PR TITLE
Use std::ptrdiff_t for vector iterator difference type

### DIFF
--- a/linbox/vector/bit-vector.inl
+++ b/linbox/vector/bit-vector.inl
@@ -46,7 +46,7 @@ namespace std
 		typedef LinBox::BitVector::reference reference;
 		typedef bool *pointer;
 		typedef bool value_type;
-		typedef long difference_type;
+		typedef std::ptrdiff_t difference_type;
 	};
 
 	template <>
@@ -56,7 +56,7 @@ namespace std
 		typedef LinBox::BitVector::const_reference reference;
 		typedef const bool *pointer;
 		typedef bool value_type;
-		typedef long difference_type;
+		typedef std::ptrdiff_t difference_type;
 	};
 }
 


### PR DESCRIPTION
It was previously long (64-bit integers), but this will not be the
case on 32-bit systems.

Closes: #273