### PR TITLE
fix for Residu_t as new type in randiters; add a Caster for NTL::ZZ

### DIFF
--- a/linbox/ring/ntl/ntl-gf2e.h
+++ b/linbox/ring/ntl/ntl-gf2e.h
@@ -50,6 +50,7 @@
 
 
 #include "linbox/integer.h"
+#include "ntl-zz.h"
 
 namespace Givaro
 {
@@ -204,7 +205,7 @@ public :
 	class UnparametricRandIter<NTL::GF2E> {
 	public:
 		typedef NTL::GF2E Element;
-        typedef Element::rep_type Residu_t;
+        typedef size_t Residu_t;
 
 		UnparametricRandIter<NTL::GF2E>(const NTL_GF2E & F,
                                         const uint64_t seed = 0,
@@ -215,7 +216,7 @@ public :
                 if(_seed == 0)
                     NTL::SetSeed(NTL::to_ZZ(time(0)));
                 else
-                    NTL::SetSeed(NTL::to_ZZ(static_cast<long unsigned int>(_seed)));
+                    NTL::SetSeed(Caster<NTL::ZZ,uint64_t>(_seed));
             }
 
 		UnparametricRandIter<NTL::GF2E>(const UnparametricRandIter<NTL::GF2E>& R) :
@@ -225,7 +226,7 @@ public :
                 if(_seed == 0)
                     NTL::SetSeed(NTL::to_ZZ(time(0)));
                 else
-                    NTL::SetSeed(NTL::to_ZZ(static_cast<long unsigned int>(_seed)));
+                    NTL::SetSeed(Caster<NTL::ZZ,uint64_t>(_seed));
             }
 
 		Element& random (Element& x) const

--- a/linbox/ring/ntl/ntl-lzz_p.h
+++ b/linbox/ring/ntl/ntl-lzz_p.h
@@ -198,11 +198,10 @@ namespace LinBox
              * Returns the modulus of the field, which should be prime.
              * @return integer representing cardinality of the field
              */
-
-		integer& cardinality(integer& c) const
-            {
-                return characteristic(c);
-            }
+		template <typename Residu_t> Residu_t &cardinality(Residu_t& c) const
+		{
+			return characteristic(c);
+		}
 
 		integer cardinality() const
             {
@@ -215,7 +214,7 @@ namespace LinBox
              * @return integer representing characteristic of the field.
              */
 
-		integer& characteristic(integer& c) const
+		template <typename Residu_t> Residu_t &characteristic(Residu_t& c) const
             {
                 return c = static_cast<int64_t>(Element::modulus());
             }
@@ -337,7 +336,7 @@ namespace LinBox
 	class UnparametricRandIter<NTL::zz_p> {
 	public:
 		typedef NTL::zz_p Element;
-        typedef Element::rep_type Residu_t;
+        typedef size_t Residu_t;
 
             /// Constructor for random field element generator
 
@@ -348,7 +347,7 @@ namespace LinBox
             {
                 if (_seed == 0) _seed = time(NULL);
 
-                integer cardinality;
+                size_t cardinality;
                 F.cardinality(cardinality);
                 if (_size > cardinality)
                     _size = 0;
@@ -378,7 +377,7 @@ namespace LinBox
             }
         const NTL_zz_p& ring() const { return _ring; }
 	protected :
-		integer _size;
+		size_t _size;
         uint64_t _seed ;
         const NTL_zz_p& _ring;
 	};

--- a/linbox/ring/ntl/ntl-lzz_pe.h
+++ b/linbox/ring/ntl/ntl-lzz_pe.h
@@ -393,7 +393,7 @@ namespace LinBox
 	class UnparametricRandIter<NTL::zz_pE> {
 	public:
 		typedef NTL::zz_pE Element;
-        typedef Element::rep_type Residu_t;
+        typedef size_t Residu_t;
 
 		UnparametricRandIter<NTL::zz_pE>(const NTL_zz_pE & F ,
                                          const uint64_t seed = 0,

--- a/linbox/ring/ntl/ntl-lzz_px.h
+++ b/linbox/ring/ntl/ntl-lzz_px.h
@@ -568,7 +568,7 @@ namespace LinBox
 	class UnparametricRandIter<NTL::zz_pX> {
 	public:
 		typedef NTL::zz_pX Element;
-        typedef Element::residue_type Residu_t;
+        typedef size_t Residu_t;
 
 		UnparametricRandIter<NTL::zz_pX>(const NTL_zz_pX & F ,
 						 const uint64_t& seed = 0,

--- a/linbox/ring/ntl/ntl-rr.h
+++ b/linbox/ring/ntl/ntl-rr.h
@@ -278,8 +278,6 @@ namespace LinBox
 
 	template <>
 	class UnparametricRandIter<NTL::RR> {
-		typedef NTL::RR Element ;
-        typedef Element Residu_t;
 
 	protected:
 		integer _size;

--- a/linbox/ring/ntl/ntl-zz.h
+++ b/linbox/ring/ntl/ntl-zz.h
@@ -37,6 +37,62 @@
 #include "linbox/randiter/ntl-zz.h"
 #include "linbox/field/field-traits.h"
 
+namespace Givaro
+{
+	/** Initialization of field element from an integer.
+	 * Behaves like C++ allocator construct.
+	 * This function assumes the output field element x has already been
+	 * constructed, but that it is not already initialized.
+	 * For now, this is done by converting the integer type to a C++
+	 * long and then to the element type through the use of static cast and
+	 * NTL's to_ZZ function.
+	 * This, of course, assumes such static casts are possible.
+	 * This function should be changed in the future to avoid using long.
+	 * @return reference to field element.
+	 * @param x field element to contain output (reference returned).
+	 * @param y integer.
+	 */
+	template <>
+	NTL::ZZ& Caster(NTL::ZZ& x, const Integer& y)
+	{
+		std::stringstream s;
+		s << y;
+		s >> x;
+		return x;
+	}
+	template <> NTL::ZZ& Caster(NTL::ZZ& x, const double& y) { return x = NTL::to_ZZ((long)(y)); }
+
+	template <> NTL::ZZ& Caster(NTL::ZZ& x, const int32_t& y) { return x = NTL::to_ZZ((long)(y)); }
+
+	template <> NTL::ZZ& Caster(NTL::ZZ& x, const int64_t& y) { return x = NTL::to_ZZ((long)(y)); }
+
+	template <> NTL::ZZ& Caster(NTL::ZZ& x, const uint32_t& y) { return x = NTL::to_ZZ((unsigned long)(y)); }
+
+	template <> NTL::ZZ& Caster(NTL::ZZ& x, const uint64_t& y) { return x = NTL::to_ZZ((unsigned long)(y)); }
+
+	/** Conversion of field element to an integer.
+	 * This function assumes the output field element x has already been
+	 * constructed, but that it is not already initialized.
+	 * For now, this is done by converting the element type to a C++
+	 * long and then to the integer type through the use of static cast and
+	 * NTL's to_long function.
+	 * This, of course, assumes such static casts are possible.
+	 * This function should be changed in the future to avoid using long.
+	 * @return reference to integer.
+	 * @param x reference to integer to contain output (reference returned).
+	 * @param y constant reference to field element.
+	 */
+	template <>
+	Integer& Caster(Integer& x, const NTL::ZZ& y)
+	{
+		std::stringstream s;
+		s << y;
+		s >> x;
+		return x;
+		//return x = static_cast<Integer>(to_long(y));
+	}
+} // namespace Givaro
+
 namespace LinBox
 {
 

--- a/linbox/ring/ntl/ntl-zz_p.h
+++ b/linbox/ring/ntl/ntl-zz_p.h
@@ -54,6 +54,7 @@
 
 
 #include "linbox/integer.h"
+#include "ntl-zz.h"
 
 namespace Givaro
 {
@@ -322,7 +323,7 @@ namespace LinBox
 		 * Returns the modulus of the field, which should be prime.
 		 * @return integer representing cardinality of the field
 		 */
-		integer& cardinality(integer& c) const
+		template <typename Residu_t> Residu_t &cardinality(Residu_t& c) const
 		{
 			return characteristic(c);
 		}
@@ -481,7 +482,7 @@ namespace LinBox
 
 	public:
         typedef NTL::ZZ_p Element;
-        typedef Element::rep_type Residu_t;
+        typedef integer Residu_t;
 
 		UnparametricRandIter<NTL::ZZ_p> (const NTL_ZZ_p & F,
 						 const uint64_t seed = 0,
@@ -524,7 +525,7 @@ namespace LinBox
 				return x = NTL::random_ZZ_p();
 			}
 			else {
-				return x = NTL::to_ZZ_p(NTL::RandomBnd(static_cast<int32_t>(_size)));
+				return x = NTL::to_ZZ_p(NTL::RandomBnd(Caster<NTL::ZZ,Residu_t>(_size)));
 			}
 		}
 

--- a/linbox/ring/ntl/ntl-zz_pe.h
+++ b/linbox/ring/ntl/ntl-zz_pe.h
@@ -46,6 +46,7 @@
 
 
 #include "linbox/integer.h"
+#include "ntl-zz.h"
 
 namespace Givaro
 {
@@ -378,7 +379,7 @@ namespace LinBox
 	class UnparametricRandIter<NTL::ZZ_pE> {
 	public:
 		typedef NTL::ZZ_pE Element;
-        typedef Element::rep_type Residu_t;
+        typedef integer Residu_t;
         UnparametricRandIter<NTL::ZZ_pE>(const NTL_ZZ_pE & F ,
 						 const uint64_t & seed =0,
 						 const Residu_t& size =0
@@ -388,11 +389,7 @@ namespace LinBox
 			if(_seed == 0)
 				NTL::SetSeed(NTL::to_ZZ(time(0)));
 			else {
-				NTL::ZZ x;
-				std::stringstream s;
-				s << seed;
-				s >> x;
-				NTL::SetSeed( x ); //NTL::to_ZZ(static_cast<long>(seed)) );
+				NTL::SetSeed( Caster<NTL::ZZ,uint64_t>(seed));
 			}
 		}
 
@@ -418,7 +415,7 @@ namespace LinBox
 			if(_seed == 0)
 				NTL::SetSeed(NTL::to_ZZ(time(0)));
 			else
-				NTL::SetSeed(NTL::to_ZZ( static_cast<long>(_seed)) );
+				NTL::SetSeed(Caster<NTL::ZZ,uint64_t>(_seed));
 		}
 
 		NTL::ZZ_pE& random (NTL::ZZ_pE& x) const
@@ -428,7 +425,7 @@ namespace LinBox
 		}
 
 	protected:
-		size_t _size;
+		Residu_t _size;
 		uint64_t _seed;
         const NTL_ZZ_pE& _ring; 
 	};


### PR DESCRIPTION
Fix the conflict implied by the joint merge of PR #257  and the givaro PR#184
Also added a `Caster` for `NTL::ZZ` and used it to fix abusive casts of `integer` to `int32_t`