### PR TITLE
Fix OpenCL issues

### DIFF
--- a/linbox/matrix/matrixdomain/opencl-domain-util.inl
+++ b/linbox/matrix/matrixdomain/opencl-domain-util.inl
@@ -473,16 +473,16 @@ namespace LinBox{
 	}
 
 	template <class Field>
-	template <class Operand1, class Operand2, class Operand3>
+	template <class Operand1, class Operand2, class Operand3, class Operand4>
 	std::vector<int> OpenCLMatrixDomain<Field>::oclPartition(
 		Operand1& D,
-		const Operand2& A,
-		const Operand3& B,
-		const Operand1& C,
+		const Operand3& A,
+		const Operand4& B,
+		const Operand2& C,
 		std::vector<SubmatrixAdapter<Operand1> >& VD,
-		std::vector<SubmatrixAdapter<Operand2> >& VA,
-		std::vector<SubmatrixAdapter<Operand3> >& VB,
-		std::vector<SubmatrixAdapter<Operand1> >& VC) const{
+		std::vector<SubmatrixAdapter<Operand3> >& VA,
+		std::vector<SubmatrixAdapter<Operand4> >& VB,
+		std::vector<SubmatrixAdapter<Operand2> >& VC) const{
 
 		//Compute if the OpenCL device is capable of working with the required ammounts of memory
 		bool memLevelsAllowed = oclMemCheck<Operand1,Operand2,Operand3>(D,A,B,C);

--- a/linbox/matrix/matrixdomain/opencl-domain.h
+++ b/linbox/matrix/matrixdomain/opencl-domain.h
@@ -414,16 +414,16 @@ namespace LinBox{
 			std::vector<SubmatrixAdapter<Operand2> >& VA,
 			std::vector<SubmatrixAdapter<Operand3> >& VB) const;
 
-		template <class Operand1, class Operand2, class Operand3>
+                template <class Operand1, class Operand2, class Operand3, class Operand4>
 		std::vector<int> oclPartition(
 			Operand1& D,
-			const Operand2& A,
-			const Operand3& B,
-			const Operand1& C,
+			const Operand3& A,
+			const Operand4& B,
+			const Operand2& C,
 			std::vector<SubmatrixAdapter<Operand1> >& VD,
-			std::vector<SubmatrixAdapter<Operand2> >& VA,
-			std::vector<SubmatrixAdapter<Operand3> >& VB,
-			std::vector<SubmatrixAdapter<Operand1> >& VC) const;
+			std::vector<SubmatrixAdapter<Operand3> >& VA,
+			std::vector<SubmatrixAdapter<Operand4> >& VB,
+			std::vector<SubmatrixAdapter<Operand2> >& VC) const;
 
 		void printClErrstring(cl_int err) const;
 #else

--- a/linbox/matrix/matrixdomain/opencl-domain.h
+++ b/linbox/matrix/matrixdomain/opencl-domain.h
@@ -555,15 +555,14 @@ namespace LinBox{
 
 		//! axpy.
 		//! D = A*B + C
-		template <class Operand1, class Operand2, class Operand3>
-		Operand1& axpy(
-			Operand1& D,
-			const Operand2& A,
-			const Operand3& B,
-			const Operand1& C) const{
-
-			return muladd(D,_F.one,C,_F.one,A,B);
-		}
+                template <class Operand1, class Operand2, class Operand3, class Operand4>
+                Operand1& axpy(
+                    Operand1& D,
+                    const Operand3& A,
+                    const Operand4& B,
+                    const Operand2& C) const{
+                    return muladd(D,_F.one,C,_F.one,A,B);
+                }
 
 		//! axpyin.
 		//! C += A*B
@@ -574,12 +573,12 @@ namespace LinBox{
 
 		//! maxpy.
 		//! D = C - A*B
-		template <class Operand1, class Operand2, class Operand3>
+            template <class Operand1, class Operand2, class Operand3, class Operand4>
 		Operand1& maxpy(
 			Operand1& D,
-			const Operand2& A,
-			const Operand3& B,
-			const Operand1& C) const{
+			const Operand3& A,
+			const Operand4& B,
+			const Operand2& C) const{
 
 			return muladd(D,_F.one,C,_F.mOne,A,B);
 		}
@@ -593,12 +592,12 @@ namespace LinBox{
 
 		//! axmy.
 		//! D= A*B - C
-		template <class Operand1, class Operand2, class Operand3>
+                template <class Operand1, class Operand2, class Operand3, class Operand4>
 		Operand1& axmy(
 			Operand1& D,
-			const Operand2& A,
-			const Operand3& B,
-			const Operand1& C) const{
+			const Operand3& A,
+			const Operand4& B,
+			const Operand2& C) const{
 
 			return muladd(D,_F.mOne,C,_F.one,A,B);
 		}

--- a/linbox/matrix/matrixdomain/opencl-domain.inl
+++ b/linbox/matrix/matrixdomain/opencl-domain.inl
@@ -74,8 +74,7 @@ namespace LinBox
 		//If it is not capable or not setup properly use default implementation
 		if(!setupCorrect || !doubleSupported || !kernelsAvailable){
 			return BlasMatrixDomainMul<Operand1,Operand2,Operand3>()(
-				_F,
-				C,
+                                C,
 				A,
 				B);
 		}
@@ -269,8 +268,7 @@ namespace LinBox
 		//If it is not capable or not setup properly use default implementation
 		if(!setupCorrect || !kernelsAvailable){
 			return BlasMatrixDomainMul<Operand1,Operand2,Operand3>()(
-				_F,
-				C,
+                                C,
 				A,
 				B);
 		}

--- a/macros/mpi-check.m4
+++ b/macros/mpi-check.m4
@@ -69,7 +69,7 @@ AC_DEFUN([LB_CHECK_MPI], [
                 ]
             )
         ],
-        [ AC_MSG_RESULT("no") ]
+        [ AC_MSG_RESULT(not found) ]
     )
 
     AM_CONDITIONAL(LINBOX_HAVE_MPI, test "x$HAVE_MPI" = "xyes")

--- a/macros/ocl-check.m4
+++ b/macros/ocl-check.m4
@@ -26,8 +26,11 @@ dnl
 dnl Test for an OpenCL
 
 AC_DEFUN([LB_CHECK_OCL],[
-	AC_ARG_WITH(ocl,
-	[AC_HELP_STRING([--with-ocl=<path>|yes|no],
+
+        AC_MSG_CHECKING(for OpenCL)
+        AC_ARG_WITH(ocl,
+                [
+                      AC_HELP_STRING([--with-ocl=<path>|yes|no],
 	[Use OpenCL. This library is optional for LinBox compilation.
 	 If argument is yes or <empty> that means the library is reachable
 	 with the standard search path "/usr" or "/usr/local" (set as default).
@@ -39,14 +42,15 @@ AC_DEFUN([LB_CHECK_OCL],[
 		OCL_HOME_PATH="$withval /opt/AMDAPP ${DEFAULT_CHECKING_PATH}"
 	fi],
 
-	[OCL_HOME_PATH="/opt/AMDAPP $DEFAULT_CHECKING_PATH}"])
+	[OCL_HOME_PATH=""
+        ])
 
 	BACKUP_CXXFLAGS=${CXXFLAGS}
 	BACKUP_LIBS=${LIBS}
 
-	if test -n "$OCL_HOME_PATH"; then
-		AC_MSG_CHECKING(for OpenCL >= 1.0)
-	fi
+	dnl if test -n "$OCL_HOME_PATH"; then
+	dnl 	AC_MSG_CHECKING(for OpenCL >= 1.0)
+	dnl fi
 
 	for OCL_HOME in ${OCL_HOME_PATH}
 	do


### PR DESCRIPTION
OpenCL code in LinBox does not compile, and therefore, when enabled, the whole library stops compiling. See #275.
This PR
* fixes many of the compilation issues, but leaves one unsolved for future work
* stop enabling OpenCL automatically when --with-ocl is not specified by opencl found
