### PR TITLE
problem with zero sequence for minpoly/charpoly

### DIFF
--- a/linbox/algorithms/bbcharpoly.h
+++ b/linbox/algorithms/bbcharpoly.h
@@ -285,8 +285,8 @@ namespace LinBox
 
 			/* Computation of the minimal polynomial */
 			Polynomial minPoly(F);
-			minpoly (minPoly, A, M);
-//             PD.write(std::cerr<<"Minpoly = ",minPoly) << std::endl;
+			minpoly (minPoly, A, M);            
+            //PD.write(std::cerr<<"Minpoly = ",minPoly) << std::endl;
 
 			if (minPoly.size() == n+1){
 				commentator().stop ("done", NULL, "MbbCharpoly");

--- a/linbox/algorithms/bbcharpoly.h
+++ b/linbox/algorithms/bbcharpoly.h
@@ -204,8 +204,8 @@ namespace LinBox
 					FM* depend = NULL;
 					for (size_t j = 1; j <= exp[i]; ++j){
 						IntPoly * tmp2 = new IntPoly(*tmp);
-// 						FieldPoly *tmp2p = new FieldPoly(tmp2->size());
-// 						typename IntPoly::template rebind<Field>() (*tmp2p, *tmp2, F);
+//						FieldPoly *tmp2p = new FieldPoly(tmp2->size());
+//						typename IntPoly::template rebind<Field>() (*tmp2p, *tmp2, F);
 						FieldPoly *tmp2p = new FieldPoly(*tmp2, F);
 
 						FFM = new FM (tmp2p, tmp2, 0, depend);
@@ -223,8 +223,8 @@ namespace LinBox
 					leadingBlocks.insert (std::pair<FM*,bool>(FFM,false));
 				}
 				else {
-// 					FieldPoly* fp=new FieldPoly(intFactors[i].size());
-// 					typename IntPoly::template rebind<Field>() (*fp, (intFactors[i]), F);
+//					FieldPoly* fp=new FieldPoly(intFactors[i].size());
+//					typename IntPoly::template rebind<Field>() (*fp, (intFactors[i]), F);
                     IntPoly * ip=new IntPoly(intFactors[i]);
 					FieldPoly* fp=new FieldPoly(intFactors[i], F);
 
@@ -285,7 +285,7 @@ namespace LinBox
 
 			/* Computation of the minimal polynomial */
 			Polynomial minPoly(F);
-			minpoly (minPoly, A, M);            
+			minpoly (minPoly, A, M);
             //PD.write(std::cerr<<"Minpoly = ",minPoly) << std::endl;
 
 			if (minPoly.size() == n+1){
@@ -293,7 +293,7 @@ namespace LinBox
 				return P = minPoly;
 			}
 
-            
+
 
 			Polynomial charPoly (F);
 

--- a/linbox/algorithms/blackbox-container-base.h
+++ b/linbox/algorithms/blackbox-container-base.h
@@ -157,11 +157,20 @@ namespace LinBox
 		{
 			casenumber = 1;
 			u.resize (_BB->coldim ());
-			for (long i = (long)u.size (); i--;)
-				g.random (u[(size_t)i]);
-			v.resize (_BB->rowdim ());
-			return _VD.dot (_value, u, u);
-		}
+            v.resize (_BB->rowdim ());
+
+            size_t trials=0;
+            do {
+                for (long i = (long)this->u.size (); i--;)
+                    g.random (this->u[(size_t)i]);
+                this->_VD.dot (this->_value, this->u, this->u);
+            } while(_field->isZero(this->_value) && ++trials<= LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE);
+
+            if (trials >= LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE)
+                std::cerr<<"ERROR in "<<__FILE__<<" at line "<<__LINE__<<" -> projection always auto-orthogonal after "<<LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE<<" attempts\n";;
+
+            return _value;
+        }
 
 		/// User Left vectors, Zero Right vector
 		template<class Vector>

--- a/linbox/algorithms/blackbox-container-base.h
+++ b/linbox/algorithms/blackbox-container-base.h
@@ -32,7 +32,7 @@
 // - wait   : waits for the end of the current computation
 // ================================================================
 
-
+#include "linbox/solutions/constants.h"
 #include "linbox/vector/vector-domain.h"
 
 namespace LinBox

--- a/linbox/algorithms/blackbox-container.h
+++ b/linbox/algorithms/blackbox-container.h
@@ -87,13 +87,23 @@ namespace LinBox
 		{
 			this->casenumber = 1;
 			this->u.resize (this->_BB->coldim ());
-			for (long i = (long)this->u.size (); i--;)
-				g.random (this->u[(size_t)i]);
-			this->w.resize (this->_BB->coldim ());
-			for (long i = (long)this->w.size (); i--;)
-				g.random (this->w[(size_t)i]);
-			this->v.resize (this->_BB->rowdim ());
-			this->_VD.dot (this->_value, this->u, this->w);
+            this->w.resize (this->_BB->coldim ());
+            this->v.resize (this->_BB->rowdim ());
+
+            size_t trials=0;
+            do {
+                for (long i = (long)this->u.size (); i--;)
+                    g.random (this->u[(size_t)i]);
+                
+                for (long i = (long)this->w.size (); i--;)
+                    g.random (this->w[(size_t)i]);
+			
+                this->_VD.dot (this->_value, this->u, this->w);
+            } while(F.isZero(this->_value) && ++trials<= LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE);
+
+            if (trials >= LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE)
+                std::cerr<<"ERROR in "<<__FILE__<<" at line "<<__LINE__<<" -> projection always orthogonal after "<<LINBOX_DEFAULT_TRIALS_BEFORE_FAILURE<<" attempts\n";;
+                
 #ifdef INCLUDE_TIMING
 			_applyTime = _dotTime = 0.0;
 #endif

--- a/linbox/algorithms/blackbox-container.h
+++ b/linbox/algorithms/blackbox-container.h
@@ -33,6 +33,7 @@
 #include "linbox/randiter/archetype.h"
 #include "linbox/algorithms/blackbox-container-base.h"
 #include "linbox/util/timer.h"
+#include "linbox/solutions/constants.h"
 
 namespace LinBox
 {

--- a/linbox/algorithms/massey-domain.h
+++ b/linbox/algorithms/massey-domain.h
@@ -348,7 +348,7 @@ namespace LinBox
 
 			commentator().stop ("done", NULL, "masseyd");
 			//		commentator().stop ("Done", "Done", "LinBox::MasseyDomain::massey");
-
+            std::cerr<<"SEQ: "<<S<<std::endl;
 			return L;
 		}
 
@@ -398,7 +398,8 @@ namespace LinBox
 		{
 			long dp = massey (phi, full_poly);
 			rank = (size_t) (v_degree(phi) - v_val (phi));
-
+            //std::cerr<<"dp="<<dp<<" rank="<<rank<<" -> "<<phi.size()<<" : "<<phi<<std::endl;
+            
             if (dp==0){// empty sequence, its minpoly is 1		
                  phi.resize(1);		
                  field().assign(phi[0],field().one);		

--- a/linbox/algorithms/massey-domain.h
+++ b/linbox/algorithms/massey-domain.h
@@ -348,7 +348,6 @@ namespace LinBox
 
 			commentator().stop ("done", NULL, "masseyd");
 			//		commentator().stop ("Done", "Done", "LinBox::MasseyDomain::massey");
-            std::cerr<<"SEQ: "<<S<<std::endl;
 			return L;
 		}
 

--- a/linbox/algorithms/wiedemann.h
+++ b/linbox/algorithms/wiedemann.h
@@ -129,7 +129,7 @@ namespace LinBox
 			<< "Time required for LSR fix:      " << WD.fixTime () << std::endl;
 #endif // INCLUDE_TIMING
 		}
-               
+
 		commentator().stop ("done", NULL, "minpoly");
 
 		return P;

--- a/tests/test-regression.C
+++ b/tests/test-regression.C
@@ -600,6 +600,37 @@ bool testZeroMatrixCharPoly() {
 
     return success;
 }
+bool testZeroSymmetricMatrixCharPoly() {
+    bool success;
+	using Ring = Givaro::Modular<double>;
+	using Matrix = SparseMatrix<Ring>;
+    Ring R(3);
+
+    Matrix A(R, 1, 1);
+    A.setEntry(0, 0, R.zero);
+
+    PolynomialRing<Ring>::Element c_A, Ex;
+
+
+    charpoly(c_A, A, RingCategories::ModularTag(), Method::Blackbox(Shape::Symmetric));
+
+    PolynomialRing<Ring> PZ(R,'X'); PZ.assign(Ex, Givaro::Degree(1), R.one);
+
+    success = PZ.areEqual(c_A, Ex);
+
+    if (!success) {
+        if (writing) {
+            std::clog<<"**** ERROR **** Fail ZSMCP " <<std::endl;
+
+            PZ.write(std::clog << "Ex: ", Ex) << std::endl;
+            PZ.write(std::clog << "cA: ", c_A) << std::endl;
+        }
+        return false;
+    } else
+        if (writing) std::cout << "ZSMCP: PASSED" << std::endl;
+
+    return success;
+}
 
 bool testFourFourMatrix() {
     bool success;
@@ -676,6 +707,7 @@ int main (int argc, char **argv)
     pass &= testZeroDimensionalCharPoly ();
     pass &= testZeroDimensionalMinPoly ();
     pass &= testZeroMatrixCharPoly();
+    pass &= testZeroSymmetricMatrixCharPoly();  
     pass &= testBigScalarCharPoly ();
     pass &= testLocalSmith ();
     pass &= testInconsistent<DenseMatrix<ZRingInts>> (Method::DenseElimination());

--- a/tests/test-regression.C
+++ b/tests/test-regression.C
@@ -570,7 +570,8 @@ bool testDixonSmallFat() {
     return success = ZZ.areEqual(r[0], b[0]);
 }
 
-bool testZeroMatrixCharPoly() {
+template<typename CMethod=Method::Blackbox>
+bool testZeroMatrixCharPoly(const CMethod& cMeth=CMethod()) {
     bool success;
 	using Ring = Givaro::Modular<double>;
 	using Matrix = SparseMatrix<Ring>;
@@ -581,7 +582,7 @@ bool testZeroMatrixCharPoly() {
 
     PolynomialRing<Ring>::Element c_A, Ex;
 
-    charpoly(c_A, A);
+    charpoly(c_A, A, RingCategories::ModularTag(), cMeth );
 
     PolynomialRing<Ring> PZ(R,'X'); PZ.assign(Ex, Givaro::Degree(1), R.one);
 
@@ -596,38 +597,7 @@ bool testZeroMatrixCharPoly() {
         }
         return false;
     } else
-        if (writing) std::cout << "ZMCP: PASSED" << std::endl;
-
-    return success;
-}
-bool testZeroSymmetricMatrixCharPoly() {
-    bool success;
-	using Ring = Givaro::Modular<double>;
-	using Matrix = SparseMatrix<Ring>;
-    Ring R(3);
-
-    Matrix A(R, 1, 1);
-    A.setEntry(0, 0, R.zero);
-
-    PolynomialRing<Ring>::Element c_A, Ex;
-
-
-    charpoly(c_A, A, RingCategories::ModularTag(), Method::Blackbox(Shape::Symmetric));
-
-    PolynomialRing<Ring> PZ(R,'X'); PZ.assign(Ex, Givaro::Degree(1), R.one);
-
-    success = PZ.areEqual(c_A, Ex);
-
-    if (!success) {
-        if (writing) {
-            std::clog<<"**** ERROR **** Fail ZSMCP " <<std::endl;
-
-            PZ.write(std::clog << "Ex: ", Ex) << std::endl;
-            PZ.write(std::clog << "cA: ", c_A) << std::endl;
-        }
-        return false;
-    } else
-        if (writing) std::cout << "ZSMCP: PASSED" << std::endl;
+        if (writing) std::cout << "ZMCP" << cMeth.name() << cMeth.shapeFlags.flags << " : PASSED" << std::endl;
 
     return success;
 }
@@ -706,8 +676,10 @@ int main (int argc, char **argv)
     pass &= testSparseDiagDet(46);
     pass &= testZeroDimensionalCharPoly ();
     pass &= testZeroDimensionalMinPoly ();
-    pass &= testZeroMatrixCharPoly();
-    pass &= testZeroSymmetricMatrixCharPoly();  
+    pass &= testZeroMatrixCharPoly<>();
+    pass &= testZeroMatrixCharPoly(Method::Blackbox(Shape::Symmetric));
+    pass &= testZeroMatrixCharPoly(Method::DenseElimination());
+//     pass &= testZeroMatrixCharPoly(Method::SparseElimination());
     pass &= testBigScalarCharPoly ();
     pass &= testLocalSmith ();
     pass &= testInconsistent<DenseMatrix<ZRingInts>> (Method::DenseElimination());


### PR DESCRIPTION
The current minpoly does not ensure that the sequence is not the zero sequence, i.e. the projection vectors are not orthogonal.
This clearly expose a bug for charpoly with the zero matrix.

This PR fixes this issue by checking the dot product of the projection vectors is not zero.

A test has been added for charpoly to cover symmetric and non symmetric case.

