### PR TITLE
Deprec

### DIFF
--- a/linbox/vector/bit-vector.inl
+++ b/linbox/vector/bit-vector.inl
@@ -339,14 +339,15 @@ namespace LinBox
 		reference _ref;
 	};
 
-	class BitVector::const_iterator : public std::iterator <std::random_access_iterator_tag, bool> {
+	class BitVector::const_iterator {
 	public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = bool;
+        using difference_type = std::ptrdiff_t;
+        using pointer = bool*;
+        using reference = BitVector::reference;
 
-		typedef std::iterator_traits<const_iterator>::iterator_category iterator_category;
-		typedef std::iterator_traits<const_iterator>::reference const_reference;
-		typedef std::iterator_traits<const_iterator>::pointer pointer;
-		typedef std::iterator_traits<const_iterator>::value_type value_type;
-		typedef std::iterator_traits<const_iterator>::difference_type difference_type;
+        typedef std::iterator_traits<const_iterator>::reference const_reference;
 		typedef BitVector::iterator iterator;
 
 		const_iterator () :

--- a/linbox/vector/vector-traits.h
+++ b/linbox/vector/vector-traits.h
@@ -149,12 +149,14 @@ namespace LinBox
 	// Helper structure used for various STL's sorts (std::list::sort and std::stable_sort)
 	// for comparison of two pairs of elements (by their first elements)
 	template<class Element>
-	struct SparseSequenceVectorPairLessThan :
-		public std::binary_function<const std::pair<size_t, Element>&, const std::pair<size_t, Element>&, bool > {
-		bool operator() (const std::pair<size_t, Element>& p1, const std::pair<size_t, Element>& p2)
-	{
-			return p1.first < p2.first;
-		}
+	struct SparseSequenceVectorPairLessThan {
+        using result_type = bool;
+        using first_argument_type = std::pair<size_t, Element>;
+        using second_argument_type = std::pair<size_t, Element>;
+        bool operator() (const first_argument_type& p1, const second_argument_type& p2)
+            {
+                return p1.first < p2.first;
+            }
 	};
 
 
@@ -250,7 +252,7 @@ namespace LinBox
 		refSpecialized (Vector &v, size_t i,
 				VectorCategories::DenseVectorTag)
 		{
-		       	return v[i];
+			return v[i];
 		}
 
 		//! @bug who is zero ?


### PR DESCRIPTION
std::iterator and std::binary_function are deprecated.
The former since C++17
The latter since C++11, and is even deleted in C++17.
Both only automatically define some useful typedefs.
Thus the replacement code explicitly define those via `using`, and is valid whichever C++ version.