### PR TITLE
Fix the size formula for an allocation

### DIFF
--- a/linbox/blackbox/apply.h
+++ b/linbox/blackbox/apply.h
@@ -593,8 +593,10 @@ namespace LinBox
 						 */
 						int rclen = (int)num_chunks*2 + 5;
 
-						unsigned char* combined = new unsigned char[(size_t)rc*_n*(size_t)rclen];
-						memset(combined, 0, (size_t)rc*_n*(size_t)rclen);
+						// https://github.com/linbox-team/linbox/issues/304#issuecomment-1766621021
+						size_t combined_size = (size_t)rc*_n*(size_t)rclen + 1;
+						unsigned char* combined = new unsigned char[combined_size];
+						memset(combined, 0, combined_size);
 
 						//order from major index to minor: combining index, component of sol'n, byte
 						//compute a product (chunk times x) for each chunk


### PR DESCRIPTION
Fixes #304 by adding one byte to the allocated size, based on the rationale offered by Jerry James, @jamesjer, in https://github.com/linbox-team/linbox/issues/304.

In addition, a new local variable is introduced for the size in question to reduce repetition.

-----

I tested this with `-D_FORTIFY_SOURCE=3` and confirmed that the tests pass.