### PR TITLE
Set SubmatrixAdapter::setEntry return type to void

### DIFF
--- a/linbox/matrix/matrixdomain/opencl-domain.h
+++ b/linbox/matrix/matrixdomain/opencl-domain.h
@@ -208,8 +208,8 @@ namespace LinBox{
 		 * @param j Column index of entry, 0...coldim() - 1
 		 * @param a_ij Element to set
 		 */
-		const Element& setEntry(size_t i, size_t j, const Element& a_ij){
-			return _Mat->setEntry(_r0 + i, _c0 + j, a_ij);
+		const void setEntry(size_t i, size_t j, const Element& a_ij){
+			_Mat->setEntry(_r0 + i, _c0 + j, a_ij);
 		}
 
 		/** Get a writeable reference to an entry in the matrix.


### PR DESCRIPTION
Fixes this error when building with OpenCL support:
```
../linbox/matrix/matrixdomain/opencl-domain.h: In instantiation of ‘const LinBox::SubmatrixAdapter<_Matrix>::Element& LinBox::SubmatrixAdapter<_Matrix>::setEntry(size_t, size_t, const Element&) [with _Matrix = LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> >; Element = double; size_t = long unsigned int]’:
../linbox/matrix/matrixdomain/opencl-domain-memory.inl:209:21:   required from ‘Operand1& LinBox::OpenCLMatrixDomain<Field_>::oclDepadMatrix(cl_mem, int, int, int, Operand1&) const [with T = double; Operand1 = LinBox::SubmatrixAdapter<LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> > >; Field_ = Givaro::Modular<double>; cl_mem = _cl_mem*]’
../linbox/matrix/matrixdomain/opencl-domain-memory.inl:315:37:   required from ‘Operand2& LinBox::OpenCLMatrixDomain<Field_>::oclReadMatrixBuffer(cl_mem, Operand2&) const [with T = double; Operand2 = LinBox::SubmatrixAdapter<LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> > >; Field_ = Givaro::Modular<double>; cl_mem = _cl_mem*]’
../linbox/matrix/matrixdomain/opencl-domain.inl:225:68:   required from ‘Operand1& LinBox::OpenCLMatrixDomain<Field_>::mul(Operand1&, const Operand2&, const Operand3&) const [with Operand1 = LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> >; Operand2 = LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> >; Operand3 = LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> >; Field_ = Givaro::Modular<double>]’
test-opencl-domain.C:138:10:   required from ‘bool testMul(const Field&, size_t, int) [with Field = Givaro::Modular<double>; size_t = long unsigned int]’
test-opencl-domain.C:762:13:   required from ‘int launch_tests(Field&, int, int) [with Field = Givaro::Modular<double>]’
test-opencl-domain.C:878:22:   required from here
../linbox/matrix/matrixdomain/opencl-domain.h:212:46: error: invalid initialization of reference of type ‘const LinBox::SubmatrixAdapter<LinBox::BlasMatrix<Givaro::Modular<double>, std::vector<double> > >::Element&’ {aka ‘const double&’} from expression of type ‘void’
  212 |                         return _Mat->setEntry(_r0 + i, _c0 + j, a_ij);
      |                                ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
```
