### PR TITLE
Fix const cast for _ld (note the underscore)

### DIFF
--- a/linbox/matrix/sparsematrix/sparse-ell-matrix.h
+++ b/linbox/matrix/sparsematrix/sparse-ell-matrix.h
@@ -1213,7 +1213,7 @@ namespace LinBox
 				const_cast<data_it>(_data_beg)  = iter._data_beg ;
 				const_cast<data_it>(_data_end)  = iter._data_end  ;
 				const_cast<Field &>(_field)     = iter._field ;
-				const_cast<size_t&>(ld)         = iter._ld ;
+				const_cast<size_t&>(_ld)        = iter._ld ;
 				_row       = iter._row ;
 
 				return *this;

--- a/linbox/matrix/sparsematrix/sparse-ellr-matrix.h
+++ b/linbox/matrix/sparsematrix/sparse-ellr-matrix.h
@@ -1106,7 +1106,7 @@ namespace LinBox
 				const_cast<element_iterator>(_data_end)= iter._data_end  ;
 				const_cast<Field &>(_field) = iter._field  ;
 				const_cast<std::vector<size_t>&>(_rowid) = iter._rowid;
-				const_cast<size_t&>(ld) = iter._ld ;
+				const_cast<size_t&>(_ld) = iter._ld ;
 				_row = iter._row ;
 
 				return *this;
@@ -1255,7 +1255,7 @@ namespace LinBox
 				const_cast<data_it>(_data_beg) = iter._data_beg ;
 				const_cast<data_it>(_data_end) = iter._data_end  ;
 				const_cast<Field &>(_field)    = iter._field ;
-				const_cast<size_t&>(ld)= iter._ld ;
+				const_cast<size_t&>(_ld)       = iter._ld ;
 				_row       = iter._row ;
 
 				return *this;


### PR DESCRIPTION
The const cast was added for gcc-14 compatibilty, but this breaks macos clang. The private field is _ld, not ld without underscore. Its somewhat surprising that it doesn't fail on gcc-14, presumably because the code path is unused.