### PR TITLE
Sparse Sequence Iterators constructors with only beg/end arguments

### DIFF
--- a/linbox/blackbox/diagonal.h
+++ b/linbox/blackbox/diagonal.h
@@ -211,7 +211,7 @@ namespace LinBox
 		std::istream& read(std::istream& is)
 		{
 			MatrixStream<Field> ms(field(), is);
-			size_t c, i, j;
+			size_t c(0), i(0), j(0);
 			if( !ms.getDimensions(_n, c) || c != _n )
 				throw ms.reportError(__FUNCTION__,__LINE__);
 			Element x; field().assign(x, field().zero);

--- a/linbox/blackbox/fibb.h
+++ b/linbox/blackbox/fibb.h
@@ -9,8 +9,8 @@
 /*
 FIBB: Fast Inverse BlackBox
 
-The FIBB functions are those of a blackbox plus rank, det, and the solvers: 
-Solve, NullSpaceRandom, NullSpaceBasis. 
+The FIBB functions are those of a blackbox plus rank, det, and the solvers:
+Solve, NullSpaceRandom, NullSpaceBasis.
 The solvers have left and right forms.
 
 THe FIBBs are Diagonal, Permutation, Triangular, and products of FIBBs in which one or both are nonsingular.
@@ -19,7 +19,7 @@ THe FIBBs are Diagonal, Permutation, Triangular, and products of FIBBs in which 
 namespace LinBox{
 
 template <class Ring>
-struct FIBB : public BB<Ring> 
+struct FIBB : public BB<Ring>
 {
 	using Field = Ring;
 	using Element = typename Ring::Element;
@@ -38,8 +38,8 @@ struct FIBB : public BB<Ring>
 
 	// solveRight and solveLeft
 	/** @brief Y: AY = X, for this A.
-		Solve nonsingular or consistent singular system.  
-		If it is consistent singular, an arbitrary solution is provided.  
+		Solve nonsingular or consistent singular system.
+		If it is consistent singular, an arbitrary solution is provided.
 		X and Y must have identical shape.
 
 		Note that Y+Z is a random sample of the solution space after
@@ -47,31 +47,31 @@ struct FIBB : public BB<Ring>
 
 		Behaviour is unspecified for inconsistent systems (see solveMP).
 	*/
-	virtual Matrix& solveRight(Matrix& Y, const Matrix& X) const 
+	virtual Matrix& solveRight(Matrix& Y, const Matrix& X) const
 	= 0;
 	/// Y: YA = X, for this A
-	virtual Matrix& solveLeft(Matrix& Y, const Matrix& X) const 
+	virtual Matrix& solveLeft(Matrix& Y, const Matrix& X) const
 	= 0;
 
 	/// N: AN = 0, each col random.
-	virtual Matrix& nullspaceRandomRight(Matrix& N) const 
+	virtual Matrix& nullspaceRandomRight(Matrix& N) const
 	= 0;
 	/// N: NA = 0, each row random.
-	virtual Matrix& nullspaceRandomLeft(Matrix& N) const 
+	virtual Matrix& nullspaceRandomLeft(Matrix& N) const
 	= 0;
 	// this generic is virtual so that it may be specialized for performance
 
 	// nullspaceBasisRight and nullspaceBasisLeft
 
 	/** B: columns are a right nullspace basis for this A.
-		
+
 		B is resized and filled so that:
 		(1) AB = 0, (2) Ax = 0 => exists y: x = By, and (3) B has full rank.
 	*/
-	virtual ResizableMatrix& nullspaceBasisRight(ResizableMatrix& B) const 
+	virtual ResizableMatrix& nullspaceBasisRight(ResizableMatrix& B) const
 	= 0;
 	/// BA= 0 and xA = 0 => exists y: x = yB and B full rank.
-	virtual ResizableMatrix& nullspaceBasisLeft(ResizableMatrix& B) const 
+	virtual ResizableMatrix& nullspaceBasisLeft(ResizableMatrix& B) const
 	= 0;
 }; // class FIBB
 
@@ -84,7 +84,7 @@ DenseMatrix<Field>& genericNullspaceRandomRight(DenseMatrix<Field>& N, const FIB
 	ResizableMatrix Xb(A.field(), N.rowdim(), N.coldim());
 	ResizableMatrix Yb(A.field(), A.rowdim(), N.coldim());
 	Matrix X(Xb); X.random();
-	Matrix Y(Yb); 
+	Matrix Y(Yb);
 	A.applyRight(Y, X); // Y = AX
 	A.solveRight(N, Y); // AN = AX
 	BlasMatrixDomain<Field> MD(A.field());
@@ -100,7 +100,7 @@ DenseMatrix<Field>& genericNullspaceRandomLeft(DenseMatrix<Field>& N, const FIBB
 	ResizableMatrix Xb(A.field(), N.rowdim(), N.coldim());
 	ResizableMatrix Yb(A.field(), N.rowdim(), A.coldim());
 	Matrix X(Xb); X.random();
-	Matrix Y(Yb); 
+	Matrix Y(Yb);
 	A.applyLeft(Y, X); // Y = XA
 	A.solveLeft(N, Y); // NA = XA
 	BlasMatrixDomain<Field> MD(A.field());

--- a/linbox/blackbox/permutation.h
+++ b/linbox/blackbox/permutation.h
@@ -110,8 +110,7 @@ namespace LinBox
 				_indices[(size_t)i] = i+1 % n;
 		}
 
-		//void random(size_t n)
-            void random(unsigned int seed= static_cast<unsigned int>(std::time(nullptr)))
+        void random(unsigned int seed= static_cast<unsigned int>(std::time(nullptr)))
 		{
 			size_t n = rowdim();
 			identity((int)n);
@@ -253,7 +252,7 @@ namespace LinBox
 					Y.setEntry(k,j, X.getEntry(x, i, j));
 			}
 		/* desired form
-		 	for (size_t i = 0; i < rowdim(); ++i)
+			for (size_t i = 0; i < rowdim(); ++i)
 			{
 				Matrix Yrow(Y, _indices[i], 0, 1, Y.coldim());
 				Matrix Xrow(X, i, 0, 1, X.coldim());

--- a/linbox/matrix/densematrix/blas-matrix.inl
+++ b/linbox/matrix/densematrix/blas-matrix.inl
@@ -71,16 +71,12 @@ namespace LinBox
 	{
         linbox_check( areFieldEqual(A.field(),field() ) );
 
-		typename _Matrix::ConstIterator         iter_value = A.Begin();
-		typename _Matrix::ConstIndexedIterator  iter_index = A.IndexedBegin();
-
-        // PG -> BUG if we use iter_value !=A.End()
-		for (;iter_index != A.IndexedEnd(); ++iter_value,++iter_index){
+		for (auto iter(A.IndexedBegin());iter != A.IndexedEnd(); ++iter){
 			int64_t i,j;
-			i=(int64_t)iter_index.rowIndex()-(int64_t)i0;
-			j=(int64_t)iter_index.colIndex()-(int64_t)j0;
+			i=(int64_t)iter.rowIndex()-(int64_t)i0;
+			j=(int64_t)iter.colIndex()-(int64_t)j0;
 			if ( (i>=0) && (j>=0) && (i< (int64_t)m) && (j < (int64_t)n))
-				setEntry((size_t)i, (size_t)j, *iter_value);
+				setEntry((size_t)i, (size_t)j, iter.value());
 		}
 	}
 

--- a/linbox/matrix/sparsematrix/read-write-sparse.inl
+++ b/linbox/matrix/sparsematrix/read-write-sparse.inl
@@ -282,7 +282,7 @@ namespace LinBox {
 		typedef typename Field::Element  Element;
 
 		MatrixStream<Field> ms(A.field(), is);
-		size_t m,n ;
+		size_t m(0),n(0) ;
 		if( !ms.getDimensions( m, n ) )
 			throw ms.reportError(__func__,__LINE__);
 		A.resize(m,n);

--- a/linbox/matrix/sparsematrix/sparse-sequence-vector.h
+++ b/linbox/matrix/sparsematrix/sparse-sequence-vector.h
@@ -97,7 +97,6 @@ namespace LinBox { namespace Protected {
 				     indices = A.IndexedBegin();
 				     (indices != A.IndexedEnd()) ;
 				     ++indices ) {
-					// hom. image (e, A.getEntry(indices.rowIndex(),indices.colIndex()) );
 					hom. image (e, indices.value() );
 					if (!Ap.field().isZero(e))
 						Ap.setEntry (indices.rowIndex(),
@@ -147,8 +146,7 @@ namespace LinBox { namespace Protected {
 				LinBox::RawVector<Element>::convert(*meit, *copit);
 		}
 
-		/** Constructor from a MatrixStream
-		*/
+            // Constructor from a MatrixStream
 		SparseMatrixGeneric ( MatrixStream<Field>& ms );
 
 		template<class VectStream>
@@ -239,10 +237,11 @@ namespace LinBox { namespace Protected {
 		public:
 			typedef _I_Element value_type;
 
-			_Iterator (const RepIterator &i, const RowIterator &j, const RepIterator &A_end) :
-				_i (i), _j (j), _A_end (A_end)
+			_Iterator (const RepIterator &i, const RepIterator &A_end) :
+				_i (i), _j (0), _A_end (A_end)
 			{
 				if( _i == _A_end ) return;
+                _j = _i->begin ();
 				while ( _j == _i->end () ) {
 					if (++_i == _A_end) return;
 					_j = _i->begin ();
@@ -266,12 +265,12 @@ namespace LinBox { namespace Protected {
 
 			bool operator == (const _Iterator &i) const
 			{
-				return (_i == i._i) && (_j == i._j);
+				return (_i == i._i) && ( (_i == _A_end) || (_j == i._j) );
 			}
 
 			bool operator != (const _Iterator &i) const
 			{
-				return (_i != i._i) || (_j != i._j);
+				return (_i != i._i) || ( (_i != _A_end) && (_j != i._j) );
 			}
 
 			_Iterator &operator ++ ()
@@ -338,20 +337,20 @@ namespace LinBox { namespace Protected {
 
 		Iterator Begin ()
 		{
-			return Iterator (_matA.begin (), _matA.front ().begin (), _matA.end ());
+			return Iterator (_matA.begin (),_matA.end ());
 		}
 
 		Iterator End ()
 		{
-			return Iterator (_matA.end (), _matA.back ().end (), _matA.end ());
+			return Iterator (_matA.end (), _matA.end ());
 		}
 		ConstIterator Begin () const
 		{
-			return ConstIterator (_matA.begin (), _matA.front ().begin (), _matA.end ());
+			return ConstIterator (_matA.begin (), _matA.end ());
 		}
 		ConstIterator End () const
 		{
-			return ConstIterator (_matA.end (), _matA.back ().end (), _matA.end ());
+			return ConstIterator (_matA.end (), _matA.end ());
 		}
 
 
@@ -381,10 +380,11 @@ namespace LinBox { namespace Protected {
 #endif
 			typedef typename IteratorValueType< RowIdxIterator >::value_type::second_type value_type;
 
-			_IndexedIterator (size_t idx, const RepIterator &i, const RowIdxIterator &j, const RepIterator &A_end) :
-				_i (i), _j (j), _A_end (A_end), _r_index (idx)
+			_IndexedIterator (size_t idx, const RepIterator &i, const RepIterator &A_end) :
+				_i (i), _j (0), _A_end (A_end), _r_index (idx)
 			{
 				if( _i == _A_end ) return;
+                _j = _i->begin ();
 				while(_j == _i->end ()) {
 					++_r_index;
 					if (++_i == _A_end) return;
@@ -413,12 +413,12 @@ namespace LinBox { namespace Protected {
 
 			bool operator == (const _IndexedIterator &i) const
 			{
-				return (_i == i._i) && (_j == i._j);
+				return (_i == i._i) && ( (_i == _A_end) || (_j == i._j) );
 			}
 
 			bool operator != (const _IndexedIterator &i) const
 			{
-				return (_i != i._i) || (_j != i._j);
+				return (_i != i._i) || ( (_i != _A_end) && (_j != i._j) );
 			}
 
 			_IndexedIterator &operator ++ ()
@@ -430,17 +430,6 @@ namespace LinBox { namespace Protected {
 					_j = _i->begin ();
 				}
 				_c_index = _j->first;
-#if 0
-				if (++_j == _i->end ()) {
-					if (++_i != _A_end) {
-						_j = _i->begin ();
-						++_r_index;
-					}
-				}
-
-				_c_index = _j->first;
-#endif
-
 				return *this;
 			}
 
@@ -516,19 +505,19 @@ namespace LinBox { namespace Protected {
 
 		IndexedIterator IndexedBegin ()
 		{
-			return IndexedIterator (0, _matA.begin (), _matA.front ().begin (), _matA.end ());
+			return IndexedIterator (0, _matA.begin (), _matA.end ());
 		}
 		IndexedIterator IndexedEnd ()
 		{
-			return IndexedIterator (_m, _matA.end (), _matA.back ().end (), _matA.end ());
+			return IndexedIterator (_m, _matA.end (), _matA.end ());
 		}
 		ConstIndexedIterator IndexedBegin () const
 		{
-			return ConstIndexedIterator (0, _matA.begin (), _matA.front ().begin (), _matA.end ());
+			return ConstIndexedIterator (0, _matA.begin (), _matA.end ());
 		}
 		ConstIndexedIterator IndexedEnd () const
 		{
-			return ConstIndexedIterator (_m, _matA.end (), _matA.back ().end (), _matA.end ());
+			return ConstIndexedIterator (_m, _matA.end (), _matA.end ());
 		}
 
 		Row &getRow (size_t i) {


### PR DESCRIPTION
Both iterator and indexed iterators now have constructor with only beg/end (on rows)
then subiterator (on columns) is set only if beg != end (that is if matrix is non-empty).

In the whole LinBox library, the above constructor suffices.
When beg != end it initializes to beg->begin(); but the latter was ill-defined otherwise, causing some instability.

If needed, it is simple enough to reintroduce the 3 arguments constructor, 
for when it is known in advance that beg != end, and when the third argument is different from "beg->begin()" ...
