### PR TITLE
Fix a compiler error on GCC 15

### DIFF
--- a/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h
+++ b/linbox/matrix/sparsematrix/sparse-tpl-matrix-omp.h
@@ -318,9 +318,9 @@ class SparseMatrix<Field_, SparseMatrixFormat::TPL_omp> : public BlackboxInterfa
 			typedef typename selfvec::const_iterator selfiter;
 			otheriter vp_p; selfiter v_p;
 
-			Ap.data_.resize(A.data.size());
+			Ap.data_.resize(A.data_.size());
 			for (v_p = A.data_.begin(), vp_p = Ap.data_.begin();
-			     v_p != A.data.end(); ++ v_p, ++ vp_p)
+			     v_p != A.data_.end(); ++ v_p, ++ vp_p)
 				hom.image (vp_p->elt, v_p->elt);
 		}
 	};


### PR DESCRIPTION
Fixes https://github.com/linbox-team/linbox/issues/321; see my comments in that issue.

There’s a lot of indirection here, and it’s hard for me to review this change from first principles, but it did allow linbox to compile and pass its test suite on GCC 15.