### PR TITLE
Fix commentator build errors in test-opencl-domain

### DIFF
--- a/tests/test-opencl-domain.C
+++ b/tests/test-opencl-domain.C
@@ -106,7 +106,8 @@ static bool testMul(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing mul"),"testMul",(size_t)iterations);
+	std::string msg = pretty("Testing mul");
+	commentator().start(msg.c_str(),"testMul",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -157,7 +158,8 @@ static bool testMulinLeft(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing mulin_left"),"testMulinLeft",(size_t)iterations);
+	std::string msg = pretty("Testing mulin_left");
+	commentator().start(msg.c_str(),"testMulinLeft",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -209,7 +211,8 @@ static bool testMulinRight(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing mulin_right"),"testMulinRight",(size_t)iterations);
+	std::string msg = pretty("Testing mulin_right");
+	commentator().start(msg.c_str(),"testMulinRight",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -261,7 +264,8 @@ static bool testAxpy(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing axpy"),"testAxpy",(size_t)iterations);
+	std::string msg = pretty("Testing axpy");
+	commentator().start(msg.c_str(),"testAxpy",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -314,7 +318,8 @@ static bool testAxpyin(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing axpyin"),"testAxpyin",(size_t)iterations);
+	std::string msg = pretty("Testing axpyin");
+	commentator().start(msg.c_str(),"testAxpyin",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -368,7 +373,8 @@ static bool testMaxpy(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing maxpy"),"testMaxpy",(size_t)iterations);
+	std::string msg = pretty("Testing maxpy");
+	commentator().start(msg.c_str(),"testMaxpy",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -421,7 +427,8 @@ static bool testMaxpyin(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing maxpyin"),"testMaxpyin",(size_t)iterations);
+	std::string msg = pretty("Testing maxpyin");
+	commentator().start(msg.c_str(),"testMaxpyin",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -475,7 +482,8 @@ static bool testAxmy(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing axmy"),"testAxmy",(size_t)iterations);
+	std::string msg = pretty("Testing axmy");
+	commentator().start(msg.c_str(),"testAxmy",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -528,7 +536,8 @@ static bool testAxmyin(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing axmyin"),"testAxmyin",(size_t)iterations);
+	std::string msg = pretty("Testing axmyin");
+	commentator().start(msg.c_str(),"testAxmyin",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -582,7 +591,8 @@ static bool testMuladd(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing muladd"),"testMuladd",(size_t)iterations);
+	std::string msg = pretty("Testing muladd");
+	commentator().start(msg.c_str(),"testMuladd",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -658,7 +668,8 @@ static bool testMuladdin(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing muladdin"),"testMuladdin",(size_t)iterations);
+	std::string msg = pretty("Testing muladdin");
+	commentator().start(msg.c_str(),"testMuladdin",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;
@@ -712,7 +723,8 @@ static bool testMulscale(const Field& F, size_t n, int iterations){
 
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDepth(3);
 	commentator().getMessageClass(INTERNAL_DESCRIPTION).setMaxDetailLevel(Commentator::LEVEL_NORMAL);
-	commentator().start(pretty("Testing mulscale"),"testMulscale",(size_t)iterations);
+	std::string msg = pretty("Testing mulscale");
+	commentator().start(msg.c_str(),"testMulscale",(size_t)iterations);
 
 	RandIter G(F);
 	bool ret = true;


### PR DESCRIPTION
The current code does not compile successfully, because `Commentator::start` does not accept `std::string` as its first argument.
