### PR TITLE
Avoid ambiguous implicit conversions from Givaro::Integer to long

### DIFF
--- a/linbox/ring/ntl/ntl-lzz_px.h
+++ b/linbox/ring/ntl/ntl-lzz_px.h
@@ -194,8 +194,11 @@ namespace LinBox
 		Element& init( Element& p, const std::vector<Coeff>& v ) const
 		{
 			p = 0;
-			for( long i = 0; i < (long)v.size(); ++i )
+			Coeff temp;
+			for( long i = 0; i < (long)v.size(); ++i ){
+				_CField.init( temp, v[ (size_t) i ] );
                 NTL::SetCoeff( p, i, v[ (size_t) i ] );
+			}
 			return p;
 		}
 

--- a/linbox/ring/ntl/ntl-lzz_px.h
+++ b/linbox/ring/ntl/ntl-lzz_px.h
@@ -197,7 +197,7 @@ namespace LinBox
 			Coeff temp;
 			for( long i = 0; i < (long)v.size(); ++i ){
 				_CField.init( temp, v[ (size_t) i ] );
-                NTL::SetCoeff( p, i, v[ (size_t) i ] );
+                NTL::SetCoeff( p, i, temp );
 			}
 			return p;
 		}


### PR DESCRIPTION
It is a compile bug in clang-21. 