### PR TITLE
Add Hadamard bound include and update determinant function

### DIFF
--- a/linbox/solutions/det.h
+++ b/linbox/solutions/det.h
@@ -34,6 +34,7 @@
 #include "linbox/blackbox/compose.h"
 #include "linbox/solutions/methods.h"
 #include "linbox/solutions/getentry.h"
+#include "linbox/solutions/hadamard-bound.h"
 #include "linbox/vector/blas-vector.h"
 
 #include "linbox/matrix/dense-matrix.h"
@@ -46,6 +47,8 @@
 #include "linbox/util/prime-stream.h"
 #include "linbox/util/debug.h"
 #include "linbox/util/mpicpp.h"
+
+#include <cmath>
 
 
 // Namespace in which all LinBox library code resides
@@ -606,6 +609,29 @@ namespace LinBox
 #include "linbox/algorithms/det-rational.h"
 namespace LinBox
 {
+
+	template <class Rep, class MyMethod>
+	Integer &det (Integer                                        &d,
+	              const BlasMatrix<Givaro::ZRing<Integer>, Rep>  &A,
+	              const RingCategories::IntegerTag               &,
+	              const MyMethod                                 &Meth)
+	{
+		if (A.coldim() != A.rowdim())
+			throw LinboxError("LinBox ERROR: matrix must be square for determinant computation\n");
+
+		if (A.coldim() == 0)
+			return d = 1;
+
+		size_t det_bound_bits = static_cast<size_t>(std::ceil(HadamardBound(A) + 1.0));
+
+		typedef Givaro::ModularBalanced<double> Field;
+		IntegerModularDet<BlasMatrix<Givaro::ZRing<Integer>, Rep>, MyMethod> iteration(A, Meth);
+		PrimeIterator<IteratorCategories::HeuristicTag> genprime(FieldTraits<Field>::bestBitSize(A.coldim()));
+		ChineseRemainder< CRABuilderFullSingle< Field > > cra(det_bound_bits);
+		cra(d, iteration, genprime);
+
+		return d;
+	}
 
 	template <class Blackbox, class MyMethod>
 	typename Blackbox::Field::Element &det (typename Blackbox::Field::Element         &d,


### PR DESCRIPTION
LinBox computes the determinant of an integer matrix `A` by Chinese
remaindering of modular determinants. In `linbox/solutions/det.h`, the
integer-tag dispatch is:

```cpp
template <class Blackbox, class MyMethod>
typename Blackbox::Field::Element &det (..., const RingCategories::IntegerTag &tag, const MyMethod &Meth)
{
    ...
    return SOLUTION_CRA_DET(d, A, tag, Meth);
}
```

`SOLUTION_CRA_DET` resolves to:

- `lif_cra_det` (from `linbox/algorithms/hybrid-det.h`) when LinBox is
  built with `__LINBOX_HAVE_NTL`, or
- `cra_det` otherwise.

The non-NTL `cra_det` path — which is the one used in the SageMath
conda environment, and is also the default in many distro packages —
uses a *heuristic* CRT driver:

```cpp
ChineseRemainder< CRABuilderEarlySingle< Field > >
    cra(LINBOX_DEFAULT_EARLY_TERMINATION_THRESHOLD);
cra(dd, iteration, genprime);
```

`CRABuilderEarlySingle` stops as soon as the running CRT reconstruction
has not changed across `LINBOX_DEFAULT_EARLY_TERMINATION_THRESHOLD`
consecutive primes. This is a *probabilistic* termination criterion:
if the residues for several primes happen to agree on a wrong lift
before the combined modulus exceeds `2|det(A)|`, `cra_det` returns the
wrong determinant.

The `lif_cra_det` (NTL) path is not a safe fallback either: in our
testing it returned `0` for nonsingular dense integer matrices in this
build configuration.
