### PR TITLE
Improve support for --without-* configure options

### DIFF
--- a/macros/flint-check.m4
+++ b/macros/flint-check.m4
@@ -46,11 +46,10 @@ AC_ARG_WITH(flint,
 	library.  ])
 ])
 
-AS_IF([test "$withval" = yes ],
+AS_IF([test "$with_flint" = yes ],
 	[ FLINT_HOME_PATH="${DEFAULT_CHECKING_PATH}" ],
-	[ test "$withval" != no ],
-	[ FLINT_HOME_PATH="$withval ${DEFAULT_CHECKING_PATH}" ],
-	[ FLINT_HOME_PATH="${DEFAULT_CHECKING_PATH}"])
+	[ test "$with_flint" != no ],
+	[ FLINT_HOME_PATH="$with_flint ${DEFAULT_CHECKING_PATH}" ])
 
 dnl  min_flint_version=ifelse([$1], ,1.0.3,$1)
 
@@ -59,7 +58,9 @@ dnl Check for existence
 BACKUP_CXXFLAGS=${CXXFLAGS}
 BACKUP_LIBS=${LIBS}
 
+if test -n "$FLINT_HOME_PATH"; then
 AC_MSG_CHECKING(for FLINT)
+fi
 
 for FLINT_HOME in ${FLINT_HOME_PATH}
   do

--- a/macros/fplll-check.m4
+++ b/macros/fplll-check.m4
@@ -60,8 +60,9 @@ BACKUP_CXXFLAGS=${CXXFLAGS}
 BACKUP_LIBS=${LIBS}
 
 version_min=4.0.1
+if test -n "$FPLLL_HOME_PATH"; then
 AC_MSG_CHECKING(for FPLLL >= $version_min)
-
+fi
 
 for FPLLL_HOME in ${FPLLL_HOME_PATH}
   do

--- a/macros/iml-check.m4
+++ b/macros/iml-check.m4
@@ -59,7 +59,9 @@ dnl Check for existence
 BACKUP_CXXFLAGS=${CXXFLAGS}
 BACKUP_LIBS=${LIBS}
 
+if test -n "$IML_HOME_PATH"; then
 AC_MSG_CHECKING(for IML)
+fi
 
 for IML_HOME in ${IML_HOME_PATH}
   do

--- a/macros/mpfr-check.m4
+++ b/macros/mpfr-check.m4
@@ -59,7 +59,9 @@ dnl Check for existence
 BACKUP_CXXFLAGS=${CXXFLAGS}
 BACKUP_LIBS=${LIBS}
 
+if test -n "$MPFR_HOME_PATH"; then
 AC_MSG_CHECKING(for MPFR)
+fi
 
 for MPFR_HOME in ${MPFR_HOME_PATH}
   do


### PR DESCRIPTION
For several dependencies, we were still printing "checking for" even when we weren't checking for anything.

Also, --without-flint was broken, as it still checked for flint in the default directories even when passed.